### PR TITLE
Version 1.6.1 (urban_api 0.14.1)

### DIFF
--- a/idu_api/common/db/migrator/versions/2024-08-28_dfb61815581e_add_level_autofix.py
+++ b/idu_api/common/db/migrator/versions/2024-08-28_dfb61815581e_add_level_autofix.py
@@ -1,0 +1,117 @@
+# pylint: disable=no-member,invalid-name,missing-function-docstring,too-many-statements
+"""add level autofix for public.territories_data
+
+Revision ID: dfb61815581e
+Revises: 7c1977523140
+Create Date: 2024-08-28 12:54:25.789593
+
+"""
+from textwrap import dedent
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "dfb61815581e"
+down_revision: Union[str, None] = "7c1977523140"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # create trigger functions
+
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE FUNCTION public.trigger_update_inner_data_on_delete()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $function$
+                BEGIN
+                    UPDATE territories_data
+                    SET
+                        parent_id = OLD.parent_id,
+                        level = OLD.level
+                    WHERE parent_id = OLD.territory_id;
+
+                    UPDATE object_geometries_data
+                    SET territory_id = OLD.parent_id
+                    WHERE territory_id = OLD.territory_id;
+
+                    RETURN OLD;
+                END;
+                $function$;
+                """
+            )
+        )
+    )
+
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE FUNCTION public.trigger_update_inner_data_on_update()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $function$
+                BEGIN
+                    IF NEW.level <> OLD.level THEN
+                        UPDATE territories_data SET level = COALESCE(NEW.level, 0) + 1
+                        WHERE parent_id = NEW.territory_id;
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $function$;
+                """
+            )
+        )
+    )
+
+    # create triggers
+
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE TRIGGER update_inner_data_on_delete_trigger
+                BEFORE DELETE ON public.territories_data
+                FOR EACH ROW
+                EXECUTE PROCEDURE public.trigger_update_inner_data_on_delete();
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE TRIGGER update_inner_data_on_update_trigger
+                BEFORE INSERT OR UPDATE ON public.territories_data
+                FOR EACH ROW
+                EXECUTE PROCEDURE public.trigger_update_inner_data_on_update();
+                """
+            )
+        )
+    )
+
+
+def downgrade() -> None:
+    # delete triggers
+
+    for table_name, trigger_name in (
+        ("public.territories_data", "update_inner_data_on_delete_trigger"),
+        ("public.territories_data", "update_inner_data_on_update_trigger"),
+    ):
+        op.execute(f"DROP TRIGGER {trigger_name} ON {table_name}")
+
+    # delete functions
+
+    for function_name in (
+        "public.trigger_update_inner_data_on_delete",
+        "public.trigger_update_inner_data_on_update",
+    ):
+        op.execute(f"DROP FUNCTION {function_name}")

--- a/idu_api/urban_api/logic/impl/helpers/territory_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/territory_objects.py
@@ -92,7 +92,6 @@ async def add_territory_to_db(
             parent_id=territory.parent_id,
             name=territory.name,
             geometry=ST_GeomFromText(str(territory.geometry.as_shapely_geometry()), text("4326")),
-            level=territory.level,
             properties=territory.properties,
             centre_point=ST_GeomFromText(str(territory.centre_point.as_shapely_geometry()), text("4326")),
             admin_center=territory.admin_center,

--- a/idu_api/urban_api/schemas/territories.py
+++ b/idu_api/urban_api/schemas/territories.py
@@ -100,7 +100,6 @@ class TerritoryDataPost(GeometryValidationModel):
     parent_id: int | None = Field(..., examples=[1])
     name: str = Field(..., description="Territory name", examples=["--"])
     geometry: Geometry = Field(..., description="Territory geometry")
-    level: int = Field(..., examples=[1])
     properties: dict[str, Any] = Field(
         default_factory=dict,
         description="Service additional properties",
@@ -118,7 +117,6 @@ class TerritoryDataPut(GeometryValidationModel):
     parent_id: int | None = Field(..., examples=[1])
     name: str = Field(..., description="Territory name", examples=["--"])
     geometry: Geometry
-    level: int = Field(..., examples=[1])
     properties: dict[str, Any] = Field(
         ...,
         description="Service additional properties",
@@ -136,7 +134,6 @@ class TerritoryDataPatch(GeometryValidationModel):
     parent_id: int | None = Field(None, examples=[1])
     name: str | None = Field(None, description="Territory name", examples=["--"])
     geometry: Geometry | None = Field(None, description="Territory geometry")
-    level: int | None = Field(None, examples=[1])
     properties: Optional[dict[str, Any]] = Field(
         None,
         description="Service additional properties",

--- a/idu_api/urban_api/version.py
+++ b/idu_api/urban_api/version.py
@@ -1,4 +1,4 @@
 """Version constants are defined here and should be updated on release."""
 
-VERSION = "0.14.0"
-LAST_UPDATE = "2024-08-26"
+VERSION = "0.14.1"
+LAST_UPDATE = "2024-08-28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idu-api"
-version = "1.6.0"
+version = "1.6.1"
 description = "This is a Digital Territories Platform API in two versions to access and manipulate basic territories data."
 authors = ["Babayev Ruslan <rus.babaef@yandex.ru>"]
 readme = "README.md"


### PR DESCRIPTION
Changes:
- remove `level` from territories POST/PUT/PATCH requests
- add automatic level property update as database trigger