### PR TITLE
Version 1.7.5 (urban_api 0.15.5)

### DIFF
--- a/idu_api/common/db/entities/__init__.py
+++ b/idu_api/common/db/entities/__init__.py
@@ -2,8 +2,10 @@
 Module to store all the database tables.
 """
 
+from idu_api.common.db.entities.buffers import buffer_types_dict, buffers_data
 from idu_api.common.db.entities.functional_zones import functional_zones_data
 from idu_api.common.db.entities.indicators_dict import indicators_dict, measurement_units_dict
+from idu_api.common.db.entities.indicators_groups import indicators_groups_data, indicators_groups_dict
 from idu_api.common.db.entities.living_buildings import living_buildings_data
 from idu_api.common.db.entities.object_geometries import object_geometries_data
 from idu_api.common.db.entities.physical_objects import physical_objects_data

--- a/idu_api/common/db/entities/buffers.py
+++ b/idu_api/common/db/entities/buffers.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Column, ForeignKey, Integer, PrimaryKeyConstraint, Sequence, String, Table
+
+from idu_api.common.db import metadata
+
+buffer_types_dict_id_seq = Sequence("buffer_types_dict_id_seq")
+
+buffer_types_dict = Table(
+    "buffer_types_dict",
+    metadata,
+    Column("buffer_type_id", Integer, primary_key=True, server_default=buffer_types_dict_id_seq.next_value()),
+    Column("name", String(length=100), nullable=False, unique=True),
+)
+
+"""
+Buffer Types Dictionary:
+- buffer_type_id int (Primary Key)
+- name string(100) (Unique)
+"""
+
+buffers_data = Table(
+    "buffers_data",
+    metadata,
+    Column("buffer_type_id", Integer, ForeignKey("buffer_types_dict.buffer_type_id"), nullable=False),
+    Column(
+        "urban_object_id", Integer, ForeignKey("urban_objects_data.urban_object_id", ondelete="CASCADE"), nullable=False
+    ),
+    Column("buffer_geometry_id", Integer, ForeignKey("object_geometries_data.object_geometry_id"), nullable=False),
+    PrimaryKeyConstraint("buffer_type_id", "urban_object_id", "buffer_geometry_id"),
+)
+
+"""
+Buffers Data:
+- buffer_type_id int (Foreign Key to buffer_types_dict)
+- urban_object_id int (Foreign Key to urban_objects_data, ondelete CASCADE)
+- buffer_geometry_id int (Foreign Key to object_geometries_data)
+"""

--- a/idu_api/common/db/entities/indicators_dict.py
+++ b/idu_api/common/db/entities/indicators_dict.py
@@ -6,9 +6,13 @@ Current list is:
 - indicators_dict
 """
 
-from sqlalchemy import Column, ForeignKey, Integer, Sequence, String, Table
+from typing import Callable
+
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Integer, Sequence, String, Table, func
 
 from idu_api.common.db import metadata
+
+func: Callable
 
 measurement_units_dict_id_seq = Sequence("measurement_units_dict_id_seq")
 
@@ -37,6 +41,8 @@ indicators_dict = Table(
     Column("level", Integer),
     Column("list_label", String(20), nullable=False),
     Column("parent_id", ForeignKey("indicators_dict.indicator_id")),
+    Column("created_at", TIMESTAMP(timezone=True), server_default=func.now(), nullable=False),
+    Column("updated_at", TIMESTAMP(timezone=True), server_default=func.now(), nullable=False),
 )
 
 """
@@ -48,4 +54,6 @@ Indicators dict:
 - level int
 - list_label string(20)
 - parent_id foreign key int
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/entities/indicators_groups.py
+++ b/idu_api/common/db/entities/indicators_groups.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, ForeignKey, Integer, PrimaryKeyConstraint, Sequence, String, Table
+
+from idu_api.common.db import metadata
+
+indicators_groups_dict_id_seq = Sequence("indicators_groups_dict_id_seq")
+
+indicators_groups_dict = Table(
+    "indicators_groups_dict",
+    metadata,
+    Column("indicators_group_id", Integer, primary_key=True, server_default=indicators_groups_dict_id_seq.next_value()),
+    Column("name", String(length=100), nullable=False, unique=True),
+)
+
+"""
+Indicators Groups Dictionary:
+- indicators_group_id int (Primary Key)
+- name string(100) (Unique)
+"""
+
+indicators_groups_data = Table(
+    "indicators_groups_data",
+    metadata,
+    Column("indicator_id", Integer, ForeignKey("indicators_dict.indicator_id", ondelete="CASCADE"), nullable=False),
+    Column(
+        "indicators_group_id",
+        Integer,
+        ForeignKey("indicators_groups_dict.indicators_group_id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    PrimaryKeyConstraint("indicator_id", "indicators_group_id"),
+)
+
+"""
+Indicators Groups Data:
+- indicator_id int (Foreign Key to indicators_dict, ondelete CASCADE)
+- indicators_group_id int (Foreign Key to indicators_groups_dict, ondelete CASCADE)
+"""

--- a/idu_api/common/db/entities/object_geometries.py
+++ b/idu_api/common/db/entities/object_geometries.py
@@ -40,4 +40,6 @@ Object geometries:
 - geometry geometry 
 - centre_point geometry point
 - address string(300)
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/entities/object_geometries.py
+++ b/idu_api/common/db/entities/object_geometries.py
@@ -2,10 +2,14 @@
 Object geometries data table is defined here
 """
 
+from typing import Callable
+
 from geoalchemy2.types import Geometry
-from sqlalchemy import Column, ForeignKey, Integer, Sequence, String, Table
+from sqlalchemy import TIMESTAMP, Column, ForeignKey, Integer, Sequence, String, Table, func
 
 from idu_api.common.db import metadata
+
+func: Callable
 
 object_geometries_data_id_seq = Sequence("object_geometries_data_id_seq")
 
@@ -25,6 +29,8 @@ object_geometries_data = Table(
         nullable=False,
     ),
     Column("address", String(300)),
+    Column("created_at", TIMESTAMP(timezone=True), server_default=func.now(), nullable=False),
+    Column("updated_at", TIMESTAMP(timezone=True), server_default=func.now(), nullable=False),
 )
 
 """

--- a/idu_api/common/db/entities/physical_objects.py
+++ b/idu_api/common/db/entities/physical_objects.py
@@ -30,4 +30,6 @@ Physical objects:
 - physical_object_type_id foreign key int
 - name string(300)
 - properties jsonb
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/entities/projects/physical_objects.py
+++ b/idu_api/common/db/entities/projects/physical_objects.py
@@ -33,5 +33,6 @@ Physical objects data:
 - physical_object_type_id foreign key int
 - name str
 - properties jsonb
-- address str
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/entities/projects/projects.py
+++ b/idu_api/common/db/entities/projects/projects.py
@@ -37,4 +37,6 @@ Project data:
 - description str
 - public bool
 - image_url str
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/entities/projects/services.py
+++ b/idu_api/common/db/entities/projects/services.py
@@ -28,8 +28,10 @@ projects_services_data = Table(
 Services data:
 - service_id int 
 - service_type_id foreign key int
+- territory_type_id foreign key int
 - name str
-- properties jsonb
-- list_label str
 - capacity_real int
+- properties jsonb
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/entities/services.py
+++ b/idu_api/common/db/entities/services.py
@@ -35,4 +35,6 @@ Services:
 - name string(200)
 - capacity_real int
 - properties jsonb
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/entities/territories.py
+++ b/idu_api/common/db/entities/territories.py
@@ -51,4 +51,6 @@ Territories:
 - centre_point geometry point
 - admin_center int
 - okato_code string(20)
+- created_at timestamp
+- updated_at timestamp
 """

--- a/idu_api/common/db/migrator/versions/2024-09-16_94e17a6f74bf_buffers_indicators_groups.py
+++ b/idu_api/common/db/migrator/versions/2024-09-16_94e17a6f74bf_buffers_indicators_groups.py
@@ -1,0 +1,124 @@
+# pylint: disable=no-member,invalid-name,missing-function-docstring,too-many-statements
+"""buffers and indicator groups added, created_at and updated_at added to object_geometries_data and indicators_dict
+
+Revision ID: 94e17a6f74bf
+Revises: 38ff7a2d4779
+Create Date: 2024-09-16 22:26:01.775927
+
+"""
+from typing import Callable, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import func
+
+func: Callable
+
+# revision identifiers, used by Alembic.
+revision: str = "94e17a6f74bf"
+down_revision: Union[str, None] = "38ff7a2d4779"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "object_geometries_data",
+        sa.Column("created_at", sa.TIMESTAMP(True), nullable=False, server_default=func.now()),
+    )
+    op.add_column(
+        "object_geometries_data",
+        sa.Column("updated_at", sa.TIMESTAMP(True), nullable=False, server_default=func.now()),
+    )
+    op.add_column(
+        "indicators_dict", sa.Column("created_at", sa.TIMESTAMP(True), nullable=False, server_default=func.now())
+    )
+    op.add_column(
+        "indicators_dict", sa.Column("updated_at", sa.TIMESTAMP(True), nullable=False, server_default=func.now())
+    )
+
+    op.execute(sa.schema.CreateSequence(sa.Sequence("buffer_types_dict_id_seq")))
+    op.execute(sa.schema.CreateSequence(sa.Sequence("indicators_groups_dict_id_seq")))
+
+    op.create_table(
+        "buffer_types_dict",
+        sa.Column(
+            "buffer_type_id",
+            sa.Integer(),
+            server_default=sa.text("nextval('buffer_types_dict_id_seq')"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint("buffer_type_id", name=op.f("buffer_types_dict_pk")),
+        sa.UniqueConstraint("name", name=op.f("buffer_types_dict_name_key")),
+    )
+
+    op.create_table(
+        "buffers_data",
+        sa.Column("buffer_type_id", sa.Integer(), nullable=False),
+        sa.Column("urban_object_id", sa.Integer(), nullable=False),
+        sa.Column("buffer_geometry_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["buffer_type_id"],
+            ["buffer_types_dict.buffer_type_id"],
+            name=op.f("buffers_data_fk_buffer_type_id__buffer_types_dict"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["urban_object_id"],
+            ["urban_objects_data.urban_object_id"],
+            name=op.f("buffers_data_fk_urban_object_id__urban_objects_data"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["buffer_geometry_id"],
+            ["object_geometries_data.object_geometry_id"],
+            name=op.f("buffers_data_fk_object_geometry_id__object_geometries"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "buffer_type_id", "urban_object_id", "buffer_geometry_id", name=op.f("buffers_data_pk")
+        ),
+    )
+
+    op.create_table(
+        "indicators_groups_dict",
+        sa.Column(
+            "indicators_group_id",
+            sa.Integer(),
+            server_default=sa.text("nextval('indicators_groups_dict_id_seq')"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint("indicators_group_id", name=op.f("indicators_groups_dict_pk")),
+        sa.UniqueConstraint("name", name=op.f("indicators_groups_dict_name_key")),
+    )
+
+    op.create_table(
+        "indicators_groups_data",
+        sa.Column("indicator_id", sa.Integer(), nullable=False),
+        sa.Column("indicators_group_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["indicator_id"],
+            ["indicators_dict.indicator_id"],
+            name=op.f("indicators_groups_data_fk_indicator_id__indicators_dict"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["indicators_group_id"],
+            ["indicators_groups_dict.indicators_group_id"],
+            name=op.f("indicators_groups_data_fk_indicators_group_id__indicators_groups_dict"),
+        ),
+        sa.PrimaryKeyConstraint("indicator_id", "indicators_group_id", name=op.f("indicators_groups_data_pk")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("indicators_groups_data")
+    op.drop_table("indicators_groups_dict")
+    op.drop_table("buffers_data")
+    op.drop_table("buffer_types_dict")
+
+    op.execute(sa.schema.DropSequence(sa.Sequence("indicators_groups_dict_id_seq")))
+    op.execute(sa.schema.DropSequence(sa.Sequence("buffer_types_dict_id_seq")))
+
+    op.drop_column("object_geometries_data", "created_at")
+    op.drop_column("object_geometries_data", "updated_at")
+    op.drop_column("indicators_dict", "created_at")
+    op.drop_column("indicators_dict", "updated_at")

--- a/idu_api/common/db/migrator/versions/2024-09-16_94e17a6f74bf_buffers_indicators_groups.py
+++ b/idu_api/common/db/migrator/versions/2024-09-16_94e17a6f74bf_buffers_indicators_groups.py
@@ -67,6 +67,7 @@ def upgrade() -> None:
             ["urban_object_id"],
             ["urban_objects_data.urban_object_id"],
             name=op.f("buffers_data_fk_urban_object_id__urban_objects_data"),
+            ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
             ["buffer_geometry_id"],
@@ -99,11 +100,13 @@ def upgrade() -> None:
             ["indicator_id"],
             ["indicators_dict.indicator_id"],
             name=op.f("indicators_groups_data_fk_indicator_id__indicators_dict"),
+            ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
             ["indicators_group_id"],
             ["indicators_groups_dict.indicators_group_id"],
             name=op.f("indicators_groups_data_fk_indicators_group_id__indicators_groups_dict"),
+            ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("indicator_id", "indicators_group_id", name=op.f("indicators_groups_data_pk")),
     )

--- a/idu_api/urban_api/dto/__init__.py
+++ b/idu_api/urban_api/dto/__init__.py
@@ -3,7 +3,7 @@ Data Transfer Objects (much like entities from database) are defined in this mod
 """
 
 from .functional_zones import FunctionalZoneDataDTO
-from .indicators import IndicatorDTO, IndicatorValueDTO, MeasurementUnitDTO
+from .indicators import IndicatorDTO, IndicatorsGroupDTO, IndicatorValueDTO, MeasurementUnitDTO
 from .living_buildings import LivingBuildingsDTO, LivingBuildingsWithGeometryDTO
 from .normatives import NormativeDTO
 from .object_geometries import ObjectGeometryDTO
@@ -38,6 +38,7 @@ __all__ = [
     "ServiceWithGeometryDTO",
     "ServiceWithTerritoriesDTO",
     "IndicatorDTO",
+    "IndicatorsGroupDTO",
     "IndicatorValueDTO",
     "MeasurementUnitDTO",
     "NormativeDTO",

--- a/idu_api/urban_api/dto/indicators.py
+++ b/idu_api/urban_api/dto/indicators.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Literal
 
 
-@dataclass
+@dataclass(frozen=True)
 class IndicatorDTO:
     indicator_id: int
     name_full: str
@@ -15,9 +15,11 @@ class IndicatorDTO:
     level: int
     list_label: str
     parent_id: int
+    created_at: datetime
+    updated_at: datetime
 
 
-@dataclass
+@dataclass(frozen=True)
 class IndicatorValueDTO:
     indicator_id: int
     name_full: str
@@ -31,7 +33,14 @@ class IndicatorValueDTO:
     information_source: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class MeasurementUnitDTO:
     measurement_unit_id: int
     name: str
+
+
+@dataclass(frozen=True)
+class IndicatorsGroupDTO:
+    indicators_group_id: int
+    name: str
+    indicators: list[IndicatorDTO]

--- a/idu_api/urban_api/dto/object_geometries.py
+++ b/idu_api/urban_api/dto/object_geometries.py
@@ -1,6 +1,7 @@
 """Object geometries DTO are defined here."""
 
 from dataclasses import dataclass
+from datetime import datetime
 
 import shapely.geometry as geom
 
@@ -12,6 +13,8 @@ class ObjectGeometryDTO:
     address: str | None
     geometry: geom.Polygon | geom.MultiPolygon | geom.Point
     centre_point: geom.Point
+    created_at: datetime
+    updated_at: datetime
 
     def __post_init__(self) -> None:
         if isinstance(self.centre_point, dict):

--- a/idu_api/urban_api/handlers/v1/indicators.py
+++ b/idu_api/urban_api/handlers/v1/indicators.py
@@ -8,6 +8,8 @@ from starlette import status
 from idu_api.urban_api.logic.indicators import IndicatorsService
 from idu_api.urban_api.schemas import (
     Indicator,
+    IndicatorsGroup,
+    IndicatorsGroupPost,
     IndicatorsPost,
     IndicatorValue,
     IndicatorValuePost,
@@ -45,6 +47,52 @@ async def add_measurement_unit(request: Request, measurement_unit: MeasurementUn
     unit = await indicators_service.add_measurement_unit(measurement_unit)
 
     return MeasurementUnit.from_dto(unit)
+
+
+@indicators_router.get(
+    "/indicators_groups",
+    response_model=list[IndicatorsGroup],
+    status_code=status.HTTP_200_OK,
+)
+async def get_indicators_groups(request: Request) -> list[IndicatorsGroup]:
+    """Get all indicators groups."""
+    indicators_service: IndicatorsService = request.state.indicators_service
+
+    groups = await indicators_service.get_indicators_groups()
+
+    return [IndicatorsGroup.from_dto(group) for group in groups]
+
+
+@indicators_router.post(
+    "/indicators_groups",
+    response_model=IndicatorsGroup,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_indicators_group(request: Request, indicators_group: IndicatorsGroupPost) -> IndicatorsGroup:
+    """Add indicators group by name and list of indicators identifiers."""
+    indicators_service: IndicatorsService = request.state.indicators_service
+
+    group = await indicators_service.add_indicators_group(indicators_group)
+
+    return IndicatorsGroup.from_dto(group)
+
+
+@indicators_router.put(
+    "/indicators_groups/{indicators_group_id}",
+    response_model=IndicatorsGroup,
+    status_code=status.HTTP_201_CREATED,
+)
+async def update_indicators_group(
+    request: Request,
+    indicators_group: IndicatorsGroupPost,
+    indicators_group_id: int = Path(..., description="indicators group identifier"),
+) -> IndicatorsGroup:
+    """Update indicators group fully by name and list of indicators identifiers."""
+    indicators_service: IndicatorsService = request.state.indicators_service
+
+    group = await indicators_service.update_indicators_group(indicators_group, indicators_group_id)
+
+    return IndicatorsGroup.from_dto(group)
 
 
 @indicators_router.get(

--- a/idu_api/urban_api/handlers/v1/territories/indicators.py
+++ b/idu_api/urban_api/handlers/v1/territories/indicators.py
@@ -40,6 +40,7 @@ async def get_indicator_values_by_territory_id(
     request: Request,
     territory_id: int = Path(..., description="territory id", gt=0),
     indicator_ids: str | None = Query(None, description="list of identifiers separated by comma"),
+    indicators_group_id: int | None = Query(None, description="to filter by indicator group (identifier)"),
     start_date: datetime | None = Query(None, description="lowest date included"),
     end_date: datetime | None = Query(None, description="highest date included"),
     value_type: ValueType = Query(None, description="to filter by value type"),
@@ -55,7 +56,14 @@ async def get_indicator_values_by_territory_id(
     value_type_field = value_type.value if value_type is not None else None
 
     indicator_values = await territories_service.get_indicator_values_by_territory_id(
-        territory_id, indicator_ids, start_date, end_date, value_type_field, information_source, last_only
+        territory_id,
+        indicator_ids,
+        indicators_group_id,
+        start_date,
+        end_date,
+        value_type_field,
+        information_source,
+        last_only,
     )
 
     return [IndicatorValue.from_dto(value) for value in indicator_values]
@@ -70,6 +78,7 @@ async def get_indicator_values_by_parent_id(
     request: Request,
     parent_id: int | None = Query(None, description="parent territory id", gt=0),
     indicator_ids: str | None = Query(None, description="list id separated by commas"),
+    indicators_group_id: int | None = Query(None, description="to filter by indicator group (identifier)"),
     start_date: datetime | None = Query(None, description="left edge"),
     end_date: datetime | None = Query(None, description="right edge"),
     value_type: ValueType = Query(None, description="to filter by value type"),
@@ -86,7 +95,14 @@ async def get_indicator_values_by_parent_id(
     value_type_field = value_type.value if value_type is not None else None
 
     territories = await territories_service.get_indicator_values_by_parent_id(
-        parent_id, indicator_ids, start_date, end_date, value_type_field, information_source, last_only
+        parent_id,
+        indicator_ids,
+        indicators_group_id,
+        start_date,
+        end_date,
+        value_type_field,
+        information_source,
+        last_only,
     )
 
     return await GeoJSONResponse.from_list([territory.to_geojson_dict() for territory in territories])

--- a/idu_api/urban_api/logic/impl/helpers/services.py
+++ b/idu_api/urban_api/logic/impl/helpers/services.py
@@ -144,7 +144,7 @@ async def put_service_to_db(conn: AsyncConnection, service: ServicesDataPut, ser
             name=service.name,
             capacity_real=service.capacity_real,
             properties=service.properties,
-            updated_at=datetime.utcnow(),
+            updated_at=datetime.now(timezone.utc),
         )
         .returning(services_data)
     )

--- a/idu_api/urban_api/logic/impl/indicators.py
+++ b/idu_api/urban_api/logic/impl/indicators.py
@@ -6,21 +6,25 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 from idu_api.urban_api.dto import (
     IndicatorDTO,
+    IndicatorsGroupDTO,
     IndicatorValueDTO,
     MeasurementUnitDTO,
 )
 from idu_api.urban_api.logic.impl.helpers.indicators import (
     add_indicator_to_db,
     add_indicator_value_to_db,
+    add_indicators_group_to_db,
     add_measurement_unit_to_db,
     get_indicator_by_id_from_db,
     get_indicator_value_by_id_from_db,
     get_indicator_values_by_id_from_db,
     get_indicators_by_parent_id_from_db,
+    get_indicators_groups_from_db,
     get_measurement_units_from_db,
+    update_indicators_group_from_db,
 )
 from idu_api.urban_api.logic.indicators import IndicatorsService
-from idu_api.urban_api.schemas import IndicatorsPost, IndicatorValuePost, MeasurementUnitPost
+from idu_api.urban_api.schemas import IndicatorsGroupPost, IndicatorsPost, IndicatorValuePost, MeasurementUnitPost
 
 
 class IndicatorsServiceImpl(IndicatorsService):
@@ -37,6 +41,17 @@ class IndicatorsServiceImpl(IndicatorsService):
 
     async def add_measurement_unit(self, measurement_unit: MeasurementUnitPost) -> MeasurementUnitDTO:
         return await add_measurement_unit_to_db(self._conn, measurement_unit)
+
+    async def get_indicators_groups(self) -> list[IndicatorsGroupDTO]:
+        return await get_indicators_groups_from_db(self._conn)
+
+    async def add_indicators_group(self, indicators_group: IndicatorsGroupPost) -> IndicatorsGroupDTO:
+        return await add_indicators_group_to_db(self._conn, indicators_group)
+
+    async def update_indicators_group(
+        self, indicators_group: IndicatorsGroupPost, indicators_group_id: int
+    ) -> IndicatorsGroupDTO:
+        return await update_indicators_group_from_db(self._conn, indicators_group, indicators_group_id)
 
     async def get_indicators_by_parent_id(
         self,

--- a/idu_api/urban_api/logic/impl/territories.py
+++ b/idu_api/urban_api/logic/impl/territories.py
@@ -1,7 +1,7 @@
 """Territories handlers logic is defined here."""
 
 from datetime import date, datetime
-from typing import Callable, Literal, Optional
+from typing import Callable, Literal
 
 import shapely.geometry as geom
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
@@ -112,10 +112,10 @@ class TerritoriesServiceImpl(TerritoriesService):  # pylint: disable=too-many-pu
     async def get_services_by_territory_id(
         self,
         territory_id: int,
-        service_type_id: Optional[int],
-        name: Optional[str],
-        order_by: Optional[Literal["created_at", "updated_at"]],
-        ordering: Optional[Literal["asc", "desc"]] = "asc",
+        service_type_id: int | None,
+        name: str | None,
+        order_by: Literal["created_at", "updated_at"] | None,
+        ordering: Literal["asc", "desc"] | None = "asc",
         paginate: bool = False,
     ) -> list[ServiceDTO] | PageDTO[ServiceDTO]:
         return await get_services_by_territory_id_from_db(
@@ -127,8 +127,8 @@ class TerritoriesServiceImpl(TerritoriesService):  # pylint: disable=too-many-pu
         territory_id: int,
         service_type_id: int | None,
         name: str | None,
-        order_by: Optional[Literal["created_at", "updated_at"]],
-        ordering: Optional[Literal["asc", "desc"]] = "asc",
+        order_by: Literal["created_at", "updated_at"] | None,
+        ordering: Literal["asc", "desc"] | None = "asc",
         paginate: bool = False,
     ) -> list[ServiceWithGeometryDTO] | PageDTO[ServiceWithGeometryDTO]:
         return await get_services_with_geometry_by_territory_id_from_db(
@@ -144,29 +144,47 @@ class TerritoriesServiceImpl(TerritoriesService):  # pylint: disable=too-many-pu
     async def get_indicator_values_by_territory_id(
         self,
         territory_id: int,
-        indicator_ids: Optional[str],
-        start_date: Optional[datetime],
-        end_date: Optional[datetime],
-        value_type: Optional[Literal["real", "target", "forecast"]],
-        information_source: Optional[str],
+        indicator_ids: str | None,
+        indicators_group_id: int | None,
+        start_date: datetime | None,
+        end_date: datetime | None,
+        value_type: Literal["real", "target", "forecast"] | None,
+        information_source: str | None,
         last_only: bool,
     ) -> list[IndicatorValueDTO]:
         return await get_indicator_values_by_territory_id_from_db(
-            self._conn, territory_id, indicator_ids, start_date, end_date, value_type, information_source, last_only
+            self._conn,
+            territory_id,
+            indicator_ids,
+            indicators_group_id,
+            start_date,
+            end_date,
+            value_type,
+            information_source,
+            last_only,
         )
 
     async def get_indicator_values_by_parent_id(
         self,
-        parent_id: Optional[int],
-        indicator_ids: Optional[str],
-        start_date: Optional[datetime],
-        end_date: Optional[datetime],
-        value_type: Optional[Literal["real", "target", "forecast"]],
-        information_source: Optional[str],
+        parent_id: int | None,
+        indicator_ids: str | None,
+        indicators_group_id: int | None,
+        start_date: datetime | None,
+        end_date: datetime | None,
+        value_type: Literal["real", "target", "forecast"] | None,
+        information_source: str | None,
         last_only: bool,
     ) -> list[TerritoryWithIndicatorsDTO]:
         return await get_indicator_values_by_parent_id_from_db(
-            self._conn, parent_id, indicator_ids, start_date, end_date, value_type, information_source, last_only
+            self._conn,
+            parent_id,
+            indicator_ids,
+            indicators_group_id,
+            start_date,
+            end_date,
+            value_type,
+            information_source,
+            last_only,
         )
 
     async def get_normatives_by_territory_id(self, territory_id: int, year: int) -> list[NormativeDTO]:
@@ -191,7 +209,7 @@ class TerritoriesServiceImpl(TerritoriesService):  # pylint: disable=too-many-pu
         return await delete_normatives_by_territory_id_in_db(self._conn, territory_id, normatives)
 
     async def get_normatives_values_by_parent_id(
-        self, parent_id: Optional[int], year: int
+        self, parent_id: int | None, year: int
     ) -> list[TerritoryWithNormativesDTO]:
         return await get_normatives_values_by_parent_id_from_db(self._conn, parent_id, year)
 
@@ -200,8 +218,8 @@ class TerritoriesServiceImpl(TerritoriesService):  # pylint: disable=too-many-pu
         territory_id: int,
         physical_object_type: int | None,
         name: str | None,
-        order_by: Optional[Literal["created_at", "updated_at"]],
-        ordering: Optional[Literal["asc", "desc"]] = "asc",
+        order_by: Literal["created_at", "updated_at"] | None,
+        ordering: Literal["asc", "desc"] | None = "asc",
         paginate: bool = False,
     ) -> list[PhysicalObjectDataDTO] | PageDTO[PhysicalObjectDataDTO]:
         return await get_physical_objects_by_territory_id_from_db(
@@ -213,8 +231,8 @@ class TerritoriesServiceImpl(TerritoriesService):  # pylint: disable=too-many-pu
         territory_id: int,
         physical_object_type: int | None,
         name: str | None,
-        order_by: Optional[Literal["created_at", "updated_at"]],
-        ordering: Optional[Literal["asc", "desc"]] = "asc",
+        order_by: Literal["created_at", "updated_at"] | None,
+        ordering: Literal["asc", "desc"] | None = "asc",
         paginate: bool = False,
     ) -> list[PhysicalObjectWithGeometryDTO] | PageDTO[PhysicalObjectWithGeometryDTO]:
         return await get_physical_objects_with_geometry_by_territory_id_from_db(
@@ -243,10 +261,10 @@ class TerritoriesServiceImpl(TerritoriesService):  # pylint: disable=too-many-pu
         self,
         parent_id: int | None,
         get_all_levels: bool,
-        order_by: Optional[Literal["created_at", "updated_at"]],
+        order_by: Literal["created_at", "updated_at"] | None,
         created_at: date | None,
         name: str | None,
-        ordering: Optional[Literal["asc", "desc"]] = "asc",
+        ordering: Literal["asc", "desc"] | None = "asc",
         paginate: bool = False,
     ) -> list[TerritoryWithoutGeometryDTO] | PageDTO[TerritoryWithoutGeometryDTO]:
         return await get_territories_without_geometry_by_parent_id_from_db(

--- a/idu_api/urban_api/logic/indicators.py
+++ b/idu_api/urban_api/logic/indicators.py
@@ -6,10 +6,11 @@ from typing import Protocol
 
 from idu_api.urban_api.dto import (
     IndicatorDTO,
+    IndicatorsGroupDTO,
     IndicatorValueDTO,
     MeasurementUnitDTO,
 )
-from idu_api.urban_api.schemas import IndicatorsPost, IndicatorValuePost, MeasurementUnitPost
+from idu_api.urban_api.schemas import IndicatorsGroupPost, IndicatorsPost, IndicatorValuePost, MeasurementUnitPost
 
 
 class IndicatorsService(Protocol):
@@ -22,6 +23,20 @@ class IndicatorsService(Protocol):
     @abc.abstractmethod
     async def add_measurement_unit(self, measurement_unit: MeasurementUnitPost) -> MeasurementUnitDTO:
         """Create measurement unit object."""
+
+    @abc.abstractmethod
+    async def get_indicators_groups(self) -> list[IndicatorsGroupDTO]:
+        """Get all indicators group objects."""
+
+    @abc.abstractmethod
+    async def add_indicators_group(self, indicators_group: IndicatorsGroupPost) -> IndicatorsGroupDTO:
+        """Create indicators group object."""
+
+    @abc.abstractmethod
+    async def update_indicators_group(
+        self, indicators_group: IndicatorsGroupPost, indicators_group_id: int
+    ) -> IndicatorsGroupDTO:
+        """Update indicators group object."""
 
     @abc.abstractmethod
     async def get_indicators_by_parent_id(

--- a/idu_api/urban_api/logic/territories.py
+++ b/idu_api/urban_api/logic/territories.py
@@ -102,13 +102,15 @@ class TerritoriesService(Protocol):  # pylint: disable=too-many-public-methods
         self,
         territory_id: int,
         indicator_ids: str | None,
+        indicators_group_id: int | None,
         start_date: datetime | None,
         end_date: datetime | None,
         value_type: Optional[Literal["real", "target", "forecast"]],
         information_source: str | None,
         last_only: bool,
     ) -> list[IndicatorValueDTO]:
-        """Get indicator values by territory id, optional indicator_ids, value_type, source and time period.
+        """Get indicator values by territory id, optional indicator_ids, indicators_group_id,
+        value_type, source and time period.
 
         Could be specified by last_only flag to get only current indicator values.
         """
@@ -118,13 +120,15 @@ class TerritoriesService(Protocol):  # pylint: disable=too-many-public-methods
         self,
         parent_id: int | None,
         indicator_ids: str | None,
+        indicators_group_id: int | None,
         start_date: datetime | None,
         end_date: datetime | None,
         value_type: Optional[Literal["real", "target", "forecast"]],
         information_source: str | None,
         last_only: bool,
     ) -> list[TerritoryWithIndicatorsDTO]:
-        """Get indicator values for child territories by parent id, optional indicator_ids, value_type, source and date.
+        """Get indicator values for child territories by parent id, optional indicator_ids, indicators_group_id,
+        value_type, source and time period.
 
         Could be specified by last_only flag to get only current indicator values.
         """

--- a/idu_api/urban_api/schemas/__init__.py
+++ b/idu_api/urban_api/schemas/__init__.py
@@ -6,6 +6,8 @@ from .functional_zones import FunctionalZoneData
 from .health_check import PingResponse
 from .indicators import (
     Indicator,
+    IndicatorsGroup,
+    IndicatorsGroupPost,
     IndicatorsPost,
     IndicatorValue,
     IndicatorValuePost,
@@ -91,6 +93,8 @@ __all__ = [
     "ServiceTypes",
     "ServiceTypesPost",
     "Indicator",
+    "IndicatorsGroup",
+    "IndicatorsGroupPost",
     "IndicatorsPost",
     "IndicatorValue",
     "IndicatorValuePost",

--- a/idu_api/urban_api/schemas/object_geometries.py
+++ b/idu_api/urban_api/schemas/object_geometries.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field, model_validator
 
 from idu_api.urban_api.dto import ObjectGeometryDTO
@@ -10,6 +12,10 @@ class ObjectGeometries(BaseModel):
     address: str | None = Field(None, description="Physical object address", examples=["--"])
     geometry: Geometry
     centre_point: Geometry
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="The time when the geometry was created")
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow, description="The time when the geometry was last updated"
+    )
 
     @classmethod
     def from_dto(cls, dto: ObjectGeometryDTO) -> "ObjectGeometries":
@@ -22,6 +28,8 @@ class ObjectGeometries(BaseModel):
             address=dto.address,
             geometry=Geometry.from_shapely_geometry(dto.geometry),
             centre_point=Geometry.from_shapely_geometry(dto.centre_point),
+            created_at=dto.created_at,
+            updated_at=dto.updated_at,
         )
 
 

--- a/idu_api/urban_api/version.py
+++ b/idu_api/urban_api/version.py
@@ -1,4 +1,4 @@
 """Version constants are defined here and should be updated on release."""
 
-VERSION = "0.15.5"
-LAST_UPDATE = "2024-09-16"
+VERSION = "0.16.0"
+LAST_UPDATE = "2024-09-20"

--- a/idu_api/urban_api/version.py
+++ b/idu_api/urban_api/version.py
@@ -1,4 +1,4 @@
 """Version constants are defined here and should be updated on release."""
 
-VERSION = "0.15.4"
-LAST_UPDATE = "2024-09-09"
+VERSION = "0.15.5"
+LAST_UPDATE = "2024-09-16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idu-api"
-version = "1.7.5"
+version = "1.8.0"
 description = "This is a Digital Territories Platform API in two versions to access and manipulate basic territories data."
 authors = ["Babayev Ruslan <rus.babaef@yandex.ru>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idu-api"
-version = "1.7.4"
+version = "1.7.5"
 description = "This is a Digital Territories Platform API in two versions to access and manipulate basic territories data."
 authors = ["Babayev Ruslan <rus.babaef@yandex.ru>"]
 readme = "README.md"


### PR DESCRIPTION
Changes:
- add `created_at` and `updated_at` columns to object_geometries_data and indicators_dict tables
- create buffer_types_dict, buffers_data, indicators_groups_dict and indicators_groups_data tables