### PR TITLE
Version 1.13.0 (urban_api 0.21.0)

### DIFF
--- a/idu_api/common/db/entities/__init__.py
+++ b/idu_api/common/db/entities/__init__.py
@@ -8,6 +8,7 @@ from idu_api.common.db.entities.indicators_dict import indicators_dict, measurem
 from idu_api.common.db.entities.indicators_groups import indicators_groups_data, indicators_groups_dict
 from idu_api.common.db.entities.living_buildings import living_buildings_data
 from idu_api.common.db.entities.object_geometries import object_geometries_data
+from idu_api.common.db.entities.physical_object_functions import physical_object_functions_dict
 from idu_api.common.db.entities.physical_objects import physical_objects_data
 from idu_api.common.db.entities.profiles_reclamation import profiles_reclamation_data
 from idu_api.common.db.entities.projects.functional_zones import projects_functional_zones_data

--- a/idu_api/common/db/entities/physical_object_functions.py
+++ b/idu_api/common/db/entities/physical_object_functions.py
@@ -1,0 +1,33 @@
+"""Physical object functions dict table is defined here."""
+
+from sqlalchemy import Column, ForeignKey, Integer, Sequence, String, Table
+
+from idu_api.common.db import metadata
+
+physical_object_functions_dict_id_seq = Sequence("physical_object_functions_dict_id_seq")
+
+physical_object_functions_dict = Table(
+    "physical_object_functions_dict",
+    metadata,
+    Column(
+        "physical_object_function_id",
+        Integer,
+        primary_key=True,
+        server_default=physical_object_functions_dict_id_seq.next_value(),
+    ),
+    Column("parent_id", Integer, ForeignKey("physical_object_functions_dict.physical_object_function_id")),
+    Column("name", String(200), nullable=False, unique=True),
+    Column("level", Integer, nullable=False),
+    Column("list_label", String(20), nullable=False, unique=True),
+    Column("code", String(50), nullable=False),
+)
+
+"""
+Physical object functions dict:
+- physical_object_function_id int 
+- parent_id foreign key int
+- name string(200)
+- level int
+- list_label string(20)
+- code string(50)
+"""

--- a/idu_api/common/db/entities/urban_types_dicts.py
+++ b/idu_api/common/db/entities/urban_types_dicts.py
@@ -8,7 +8,8 @@ Current list is:
 - service_types_dict
 """
 
-from sqlalchemy import Column, Enum, ForeignKey, Integer, Sequence, String, Table, Text
+from sqlalchemy import Column, Enum, ForeignKey, Integer, Sequence, String, Table, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
 
 from idu_api.common.db import metadata
 from idu_api.common.db.entities.enums import InfrastructureType
@@ -49,12 +50,19 @@ physical_object_types_dict = Table(
         server_default=physical_object_types_dict_id_seq.next_value(),
     ),
     Column("name", String(200), nullable=False, unique=True),
+    Column(
+        "physical_object_function_id",
+        Integer,
+        ForeignKey("physical_object_functions_dict.physical_object_function_id"),
+        nullable=True,
+    ),
 )
 
 """
 Physical object types:
 - physical_object_type_id int 
 - name string(200)
+- physical_object_function_id foreign key int
 """
 
 territory_types_dict_id_seq = Sequence("territory_types_dict_id_seq")
@@ -84,6 +92,7 @@ service_types_dict = Table(
     Column("capacity_modeled", Integer),
     Column("code", String(50), nullable=False),
     Column("infrastructure_type", InfrastructureTypeEnum, default=InfrastructureType.basic, nullable=False),
+    Column("properties", JSONB(astext_type=Text()), nullable=False, server_default=text("'{}'::jsonb")),
 )
 
 """
@@ -94,4 +103,5 @@ Service types:
 - capacity_modeled int
 - code string(50)
 - infrastructure_type enum
+- properties jsonb
 """

--- a/idu_api/common/db/migrator/versions/2024-10-21_1_fba380fb8c8a_physical_objects_functions.py
+++ b/idu_api/common/db/migrator/versions/2024-10-21_1_fba380fb8c8a_physical_objects_functions.py
@@ -1,0 +1,402 @@
+# pylint: disable=no-member,invalid-name,missing-function-docstring,too-many-statements
+"""physical objects functions
+
+Revision ID: fba380fb8c8a
+Revises: 4eadb660d27b
+Create Date: 2024-10-21 13:34:25.960008
+
+"""
+from textwrap import dedent
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "fba380fb8c8a"
+down_revision: Union[str, None] = "4eadb660d27b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # create table `physical_object_function_dict`
+    op.execute(sa.schema.CreateSequence(sa.Sequence("physical_object_functions_dict_id_seq")))
+    op.create_table(
+        "physical_object_functions_dict",
+        sa.Column(
+            "physical_object_function_id",
+            sa.Integer(),
+            server_default=sa.text("nextval('physical_object_functions_dict_id_seq')"),
+            nullable=False,
+        ),
+        sa.Column("parent_id", sa.Integer(), nullable=True),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("level", sa.Integer(), nullable=False),
+        sa.Column("list_label", sa.String(length=20), nullable=False),
+        sa.Column("code", sa.String(length=50), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["parent_id"],
+            ["physical_object_functions_dict.physical_object_function_id"],
+            name=op.f("physical_object_functions_dict_fk_parent_id__physical_object_functions_dict"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("physical_object_function_id", name=op.f("physical_object_functions_dict_pk")),
+        sa.UniqueConstraint("list_label", name=op.f("physical_object_functions_dict_list_label_key")),
+        sa.UniqueConstraint("name", name=op.f("physical_object_functions_dict_name_key")),
+    )
+
+    # create functions/triggers to auto-set po functions level on insert/update/delete
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE FUNCTION public.trigger_update_po_function_level_on_insert()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $function$
+                BEGIN
+                    NEW.level := (
+                        SELECT COALESCE(
+                            (SELECT level
+                            FROM physical_object_functions_dict
+                            WHERE physical_object_function_id = NEW.parent_id), 0) + 1
+                    );
+                    RETURN NEW;
+                END;
+                $function$;
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE TRIGGER update_po_function_level_on_insert_trigger
+                BEFORE INSERT ON public.physical_object_functions_dict
+                FOR EACH ROW
+                EXECUTE PROCEDURE public.trigger_update_po_function_level_on_insert();
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE FUNCTION public.trigger_update_po_function_level_on_update()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $function$
+                BEGIN
+                    IF NEW.level <> OLD.level THEN
+                        UPDATE physical_object_functions_dict 
+                        SET level = NEW.level + 1           
+                        WHERE parent_id = NEW.physical_object_function_id;
+                    END IF;
+
+                    IF NEW.parent_id <> OLD.parent_id OR 
+                    NEW.parent_id IS NULL AND OLD.parent_id IS NOT NULL OR
+                    NEW.parent_id IS NOT NULL AND OLD.parent_id IS NULL
+                    THEN
+                        UPDATE physical_object_functions_dict 
+                        SET level = (
+                            SELECT COALESCE(
+                                (SELECT level
+                                FROM physical_object_functions_dict
+                                WHERE physical_object_function_id = NEW.parent_id), 0) + 1
+                        )                  
+                        WHERE physical_object_function_id = NEW.physical_object_function_id;
+                    END IF;
+                    RETURN NEW;
+                END;
+                $function$;
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE TRIGGER update_po_function_level_on_update_trigger
+                AFTER UPDATE ON public.physical_object_functions_dict
+                FOR EACH ROW
+                EXECUTE FUNCTION public.trigger_update_po_function_level_on_update();
+                """
+            )
+        )
+    )
+
+    # create functions/triggers to auto-set po_function list_label on insert/update/delete
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                -- Функция для генерации list_label
+                CREATE FUNCTION public.trigger_generate_po_function_list_label()
+                RETURNS TRIGGER AS $$
+                DECLARE
+                    parent_label TEXT;
+                    next_number INT;
+                BEGIN
+                    -- Если это корневая функция (нет родительской функции)
+                    IF NEW.parent_id IS NULL THEN
+                        -- Считаем количество корневых функций и формируем list_label для нового элемента
+                        NEW.list_label := (SELECT COUNT(*) + 1 FROM physical_object_functions_dict WHERE parent_id IS NULL)::TEXT;
+                    ELSE
+                        -- Получаем list_label родительской функции
+                        SELECT list_label INTO parent_label
+                        FROM physical_object_functions_dict
+                        WHERE physical_object_function_id = NEW.parent_id;
+
+                        NEW.list_label := parent_label || '.' || (SELECT COUNT(*) + 1 FROM physical_object_functions_dict WHERE parent_id = NEW.parent_id)::TEXT;
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE TRIGGER update_po_function_list_label_on_insert_trigger
+                BEFORE INSERT ON public.physical_object_functions_dict
+                FOR EACH ROW
+                EXECUTE FUNCTION public.trigger_generate_po_function_list_label();
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE FUNCTION public.trigger_update_po_function_list_label_on_update()
+                RETURNS TRIGGER AS $$
+                DECLARE
+                    parent_label TEXT;
+                    new_label TEXT;
+                    sibling_label TEXT;
+                    position INT := 0;
+                BEGIN
+                    -- Проверка на изменение list_label
+                    IF NEW.list_label <> OLD.list_label THEN
+                        -- Перенумеровываем дочерние функции для обновленной
+                        FOR sibling_label IN
+                            SELECT list_label FROM physical_object_functions_dict
+                            WHERE parent_id = NEW.physical_object_function_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := NEW.list_label || '.' || position;
+
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    -- Проверка на изменение родительской функции
+                    IF NEW.parent_id <> OLD.parent_id OR 
+                    NEW.parent_id IS NULL AND OLD.parent_id IS NOT NULL OR
+                    NEW.parent_id IS NOT NULL AND OLD.parent_id IS NULL
+                    THEN
+                        -- Если это корневая функция (нет родительской функции)
+                        IF NEW.parent_id IS NULL THEN
+                            new_label := (SELECT COUNT(*) FROM physical_object_functions_dict WHERE parent_id IS NULL)::TEXT;
+
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE physical_object_function_id = NEW.physical_object_function_id;
+                        ELSE
+                            SELECT list_label INTO parent_label
+                            FROM physical_object_functions_dict
+                            WHERE physical_object_function_id = NEW.parent_id;
+
+                            new_label := parent_label || '.' || (SELECT COUNT(*) FROM physical_object_functions_dict WHERE parent_id = NEW.parent_id)::TEXT;
+
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE physical_object_function_id = NEW.physical_object_function_id;
+                        END IF;
+
+                        -- Если старая функция была корневой
+                        IF OLD.parent_id IS NULL THEN
+                            FOR sibling_label IN
+                                SELECT list_label FROM physical_object_functions_dict
+                                WHERE parent_id IS NULL
+                                ORDER BY list_label
+                            LOOP
+                                position := position + 1;
+                                new_label := position::TEXT;
+
+                                UPDATE physical_object_functions_dict
+                                SET list_label = new_label
+                                WHERE list_label = sibling_label;
+                            END LOOP;
+                        ELSE
+                            -- Получаем label родительской функции
+                            SELECT list_label INTO parent_label
+                            FROM physical_object_functions_dict
+                            WHERE physical_object_function_id = OLD.parent_id;
+                        END IF;
+
+                        -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                        FOR sibling_label IN
+                            SELECT list_label FROM physical_object_functions_dict
+                            WHERE parent_id = OLD.parent_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := parent_label || '.' || position;
+
+                            -- Обновляем list_label для функции на текущем уровне
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE TRIGGER update_po_function_list_label_on_update_trigger
+                AFTER UPDATE ON public.physical_object_functions_dict
+                FOR EACH ROW
+                EXECUTE FUNCTION public.trigger_update_po_function_list_label_on_update();
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE FUNCTION public.trigger_update_po_function_sibling_labels_on_delete()
+                RETURNS TRIGGER AS $$
+                DECLARE
+                    sibling_label TEXT;
+                    new_label TEXT;
+                    parent_label TEXT;
+                    position INT := 0; -- Инициализируем переменную
+                BEGIN
+                    -- Если удаленная функция корневая, обновляем функции 1-го уровня
+                    IF OLD.parent_id IS NULL THEN
+                        FOR sibling_label IN
+                            SELECT list_label FROM physical_object_functions_dict
+                            WHERE parent_id IS NULL
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+
+                            -- Новое значение list_label для корневой функции
+                            new_label := position::TEXT;
+
+                            -- Обновляем list_label для корневой функции
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    ELSE
+                        -- Получаем label родительской функции
+                        SELECT list_label INTO parent_label
+                        FROM physical_object_functions_dict
+                        WHERE physical_object_function_id = OLD.parent_id;
+                    END IF;
+
+                    -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                    FOR sibling_label IN
+                        SELECT list_label FROM physical_object_functions_dict
+                        WHERE parent_id = OLD.parent_id
+                        ORDER BY list_label
+                    LOOP
+                        position := position + 1;
+                        new_label := parent_label || '.' || position;
+
+                        -- Обновляем list_label для функции на текущем уровне
+                        UPDATE physical_object_functions_dict
+                        SET list_label = new_label
+                        WHERE list_label = sibling_label;
+                    END LOOP;
+
+                    RETURN OLD;
+                END;
+                $$ LANGUAGE plpgsql;
+                """
+            )
+        )
+    )
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE TRIGGER reorder_po_function_sibling_labels_on_delete_trigger
+                AFTER DELETE ON public.physical_object_functions_dict
+                FOR EACH ROW
+                EXECUTE FUNCTION public.trigger_update_po_function_sibling_labels_on_delete();
+                """
+            )
+        )
+    )
+
+    # add column `physical_object_function_id` to `physical_object_types_dict`
+    op.add_column("physical_object_types_dict", sa.Column("physical_object_function_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "po_types_dict_fk_po_function_id__po_functions_dict",
+        "physical_object_types_dict",
+        "physical_object_functions_dict",
+        ["physical_object_function_id"],
+        ["physical_object_function_id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    # drop column `physical_object_function_id` from `physical_object_types_dict`
+    op.drop_constraint("po_types_dict_fk_po_function_id__po_functions_dict", "physical_object_types_dict", "foreignkey")
+    op.drop_column("physical_object_types_dict", "physical_object_function_id")
+
+    # drop triggers/function to auto-set po_function level
+    op.execute(
+        "DROP TRIGGER IF EXISTS update_po_function_level_on_update_trigger " "ON public.physical_object_functions_dict"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS update_po_function_level_on_insert_trigger " "ON public.physical_object_functions_dict"
+    )
+    op.execute("DROP FUNCTION IF EXISTS public.trigger_update_po_function_level_on_insert")
+    op.execute("DROP FUNCTION IF EXISTS public.trigger_update_po_function_level_on_update")
+
+    # drop triggers/functions to auto-set po_function list label
+    op.execute(
+        "DROP TRIGGER IF EXISTS reorder_po_function_sibling_labels_on_delete_trigger "
+        "ON public.physical_object_functions_dict"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS update_po_function_list_label_on_update_trigger "
+        "ON public.physical_object_functions_dict"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS update_po_function_list_label_on_insert_trigger "
+        "ON public.physical_object_functions_dict"
+    )
+    op.execute("DROP FUNCTION IF EXISTS public.trigger_update_po_function_sibling_labels_on_delete")
+    op.execute("DROP FUNCTION IF EXISTS public.trigger_update_po_function_list_label_on_update")
+    op.execute("DROP FUNCTION IF EXISTS public.trigger_generate_po_function_list_label")
+
+    # drop table `physical_object_function_dict`
+    op.drop_table("physical_object_functions_dict")
+    op.execute(sa.schema.DropSequence(sa.Sequence("physical_object_functions_dict_id_seq")))

--- a/idu_api/common/db/migrator/versions/2024-10-21_2_1a5a48e94edf_service_types_properties.py
+++ b/idu_api/common/db/migrator/versions/2024-10-21_2_1a5a48e94edf_service_types_properties.py
@@ -1,0 +1,34 @@
+# pylint: disable=no-member,invalid-name,missing-function-docstring,too-many-statements
+"""service types properties
+
+Revision ID: 1a5a48e94edf
+Revises: fba380fb8c8a
+Create Date: 2024-10-21 14:02:54.683056
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "1a5a48e94edf"
+down_revision: Union[str, None] = "fba380fb8c8a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # add column `properties` to `service_types_dict`
+    op.add_column(
+        "service_types_dict",
+        sa.Column(
+            "properties", postgresql.JSONB(astext_type=sa.Text()), server_default=sa.text("'{}'::jsonb"), nullable=False
+        ),
+    )
+
+
+def downgrade() -> None:
+    # drop column `properties` from `service_types_dict`
+    op.drop_column("service_types_dict", "properties")

--- a/idu_api/common/db/migrator/versions/2024-10-22_60365c39941e_po_functions_not_null.py
+++ b/idu_api/common/db/migrator/versions/2024-10-22_60365c39941e_po_functions_not_null.py
@@ -1,0 +1,27 @@
+# pylint: disable=no-member,invalid-name,missing-function-docstring,too-many-statements
+"""po functions not null
+
+Revision ID: 60365c39941e
+Revises: 1a5a48e94edf
+Create Date: 2024-10-22 11:26:42.604032
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "60365c39941e"
+down_revision: Union[str, None] = "1a5a48e94edf"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # set not null for column `physical_object_function_id`
+    op.alter_column("physical_object_types_dict", "physical_object_function_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("physical_object_types_dict", "physical_object_function_id", nullable=True)

--- a/idu_api/urban_api/dto/__init__.py
+++ b/idu_api/urban_api/dto/__init__.py
@@ -1,6 +1,4 @@
-"""
-Data Transfer Objects (much like entities from database) are defined in this module.
-"""
+"""Data Transfer Objects (much like entities from database) are defined in this module."""
 
 from .functional_zones import FunctionalZoneDataDTO, FunctionalZoneTypeDTO
 from .indicators import IndicatorDTO, IndicatorsGroupDTO, IndicatorValueDTO, MeasurementUnitDTO
@@ -8,9 +6,13 @@ from .living_buildings import LivingBuildingsDTO, LivingBuildingsWithGeometryDTO
 from .normatives import NormativeDTO
 from .object_geometries import ObjectGeometryDTO
 from .pages import PageDTO
+from .physical_object_types import (
+    PhysicalObjectFunctionDTO,
+    PhysicalObjectTypeDTO,
+    PhysicalObjectTypesHierarchyDTO,
+)
 from .physical_objects import (
     PhysicalObjectDataDTO,
-    PhysicalObjectTypeDTO,
     PhysicalObjectWithGeometryDTO,
     PhysicalObjectWithTerritoryDTO,
 )
@@ -52,7 +54,9 @@ __all__ = [
     "ObjectGeometryDTO",
     "PageDTO",
     "PhysicalObjectDataDTO",
+    "PhysicalObjectFunctionDTO",
     "PhysicalObjectTypeDTO",
+    "PhysicalObjectTypesHierarchyDTO",
     "PhysicalObjectWithGeometryDTO",
     "PhysicalObjectWithTerritoryDTO",
     "LivingBuildingsDTO",

--- a/idu_api/urban_api/dto/living_buildings.py
+++ b/idu_api/urban_api/dto/living_buildings.py
@@ -13,6 +13,8 @@ class LivingBuildingsWithGeometryDTO:  # pylint: disable=too-many-instance-attri
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
+    physical_object_function_id: int
+    physical_object_function_name: str
     physical_object_name: str | None
     physical_object_properties: dict[str, str]
     physical_object_created_at: datetime
@@ -40,6 +42,8 @@ class LivingBuildingsDTO:  # pylint: disable=too-many-instance-attributes
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
+    physical_object_function_id: int
+    physical_object_function_name: str
     physical_object_name: str | None
     physical_object_properties: dict[str, Any]
     physical_object_created_at: datetime

--- a/idu_api/urban_api/dto/living_buildings.py
+++ b/idu_api/urban_api/dto/living_buildings.py
@@ -13,8 +13,8 @@ class LivingBuildingsWithGeometryDTO:  # pylint: disable=too-many-instance-attri
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
-    physical_object_function_id: int
-    physical_object_function_name: str
+    physical_object_function_id: int | None
+    physical_object_function_name: str | None
     physical_object_name: str | None
     physical_object_properties: dict[str, str]
     physical_object_created_at: datetime

--- a/idu_api/urban_api/dto/physical_object_types.py
+++ b/idu_api/urban_api/dto/physical_object_types.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Self
+
+
+@dataclass(frozen=True)
+class PhysicalObjectTypeDTO:
+    """Physical object type with all its attributes."""
+
+    physical_object_type_id: int
+    name: str
+    physical_object_function_id: int | None
+    physical_object_function_name: str | None
+
+
+@dataclass(frozen=True)
+class PhysicalObjectFunctionDTO:
+    """Physical object function with all its attributes."""
+
+    physical_object_function_id: int
+    parent_id: int | None
+    parent_name: str | None
+    name: str
+    level: int
+    list_label: str
+    code: str
+
+
+@dataclass(frozen=True)
+class PhysicalObjectTypesHierarchyDTO:
+    """Physical object hierarchy DTO."""
+
+    physical_object_function_id: int
+    parent_id: int | None
+    name: str
+    level: int
+    list_label: str
+    code: str
+    children: list[Self | PhysicalObjectTypeDTO]

--- a/idu_api/urban_api/dto/physical_objects.py
+++ b/idu_api/urban_api/dto/physical_objects.py
@@ -12,8 +12,8 @@ class PhysicalObjectDataDTO:
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
-    physical_object_function_id: int
-    physical_object_function_name: str
+    physical_object_function_id: int | None
+    physical_object_function_name: str | None
     name: str | None
     properties: dict[str, Any]
     created_at: datetime
@@ -25,8 +25,8 @@ class PhysicalObjectWithGeometryDTO:
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
-    physical_object_function_id: int
-    physical_object_function_name: str
+    physical_object_function_id: int | None
+    physical_object_function_name: str | None
     name: str | None
     address: str | None
     osm_id: str | None
@@ -49,12 +49,15 @@ class PhysicalObjectWithGeometryDTO:
         physical_object_type = {
             "physical_object_type_id": physical_object.pop("physical_object_type_id", None),
             "name": physical_object.pop("physical_object_type_name", None),
-            "physical_object_function": {
-                "id": physical_object.pop("physical_object_function_id", None),
-                "name": physical_object.pop("physical_object_function_name", None),
-            },
+            "physical_object_function": None,
+        }
+        physical_object_function = {
+            "id": physical_object.pop("physical_object_function_id", None),
+            "name": physical_object.pop("physical_object_function_name", None),
         }
         physical_object["physical_object_type"] = physical_object_type
+        if physical_object_function["id"] is not None:
+            physical_object["physical_object_type"]["physical_object_function"] = physical_object_function
 
         return physical_object
 
@@ -64,8 +67,8 @@ class PhysicalObjectWithTerritoryDTO:
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
-    physical_object_function_id: int
-    physical_object_function_name: str
+    physical_object_function_id: int | None
+    physical_object_function_name: str | None
     name: str | None
     properties: dict[str, Any]
     territories: list[dict[str, Any]]

--- a/idu_api/urban_api/dto/physical_objects.py
+++ b/idu_api/urban_api/dto/physical_objects.py
@@ -8,18 +8,12 @@ import shapely.geometry as geom
 
 
 @dataclass(frozen=True)
-class PhysicalObjectTypeDTO:
-    """Physical object type with all its attributes."""
-
-    physical_object_type_id: int
-    name: str
-
-
-@dataclass(frozen=True)
 class PhysicalObjectDataDTO:
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
+    physical_object_function_id: int
+    physical_object_function_name: str
     name: str | None
     properties: dict[str, Any]
     created_at: datetime
@@ -31,6 +25,8 @@ class PhysicalObjectWithGeometryDTO:
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
+    physical_object_function_id: int
+    physical_object_function_name: str
     name: str | None
     address: str | None
     osm_id: str | None
@@ -53,6 +49,10 @@ class PhysicalObjectWithGeometryDTO:
         physical_object_type = {
             "physical_object_type_id": physical_object.pop("physical_object_type_id", None),
             "name": physical_object.pop("physical_object_type_name", None),
+            "physical_object_function": {
+                "id": physical_object.pop("physical_object_function_id", None),
+                "name": physical_object.pop("physical_object_function_name", None),
+            },
         }
         physical_object["physical_object_type"] = physical_object_type
 
@@ -64,6 +64,8 @@ class PhysicalObjectWithTerritoryDTO:
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
+    physical_object_function_id: int
+    physical_object_function_name: str
     name: str | None
     properties: dict[str, Any]
     territories: list[dict[str, Any]]

--- a/idu_api/urban_api/dto/scenarios_urban_objects.py
+++ b/idu_api/urban_api/dto/scenarios_urban_objects.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import shapely.geometry as geom
 
@@ -12,6 +12,8 @@ class ScenarioUrbanObjectDTO:  # pylint: disable=too-many-instance-attributes
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
+    physical_object_function_id: int
+    physical_object_function_name: str
     physical_object_name: str | None
     physical_object_properties: dict[str, Any]
     physical_object_created_at: datetime
@@ -32,11 +34,12 @@ class ScenarioUrbanObjectDTO:  # pylint: disable=too-many-instance-attributes
     service_type_capacity_modeled: int | None
     service_type_code: str | None
     infrastructure_type: str | None
+    service_type_properties: dict[str, Any] | None
     territory_type_id: int | None
     territory_type_name: str | None
     service_name: str | None
     capacity_real: int | None
-    service_properties: Optional[dict[str, Any]]
+    service_properties: dict[str, Any] | None
     service_created_at: datetime | None
     service_updated_at: datetime | None
 

--- a/idu_api/urban_api/dto/scenarios_urban_objects.py
+++ b/idu_api/urban_api/dto/scenarios_urban_objects.py
@@ -12,8 +12,8 @@ class ScenarioUrbanObjectDTO:  # pylint: disable=too-many-instance-attributes
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
-    physical_object_function_id: int
-    physical_object_function_name: str
+    physical_object_function_id: int | None
+    physical_object_function_name: str | None
     physical_object_name: str | None
     physical_object_properties: dict[str, Any]
     physical_object_created_at: datetime

--- a/idu_api/urban_api/dto/service_types.py
+++ b/idu_api/urban_api/dto/service_types.py
@@ -1,7 +1,7 @@
 """Service types DTO are defined here."""
 
 from dataclasses import dataclass
-from typing import Literal, Self
+from typing import Any, Literal, Self
 
 
 @dataclass(frozen=True)
@@ -13,6 +13,7 @@ class ServiceTypesDTO:
     capacity_modeled: int | None
     code: str
     infrastructure_type: Literal["basic", "additional", "comfort"]
+    properties: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/idu_api/urban_api/dto/services.py
+++ b/idu_api/urban_api/dto/services.py
@@ -17,6 +17,7 @@ class ServiceDTO:  # pylint: disable=too-many-instance-attributes
     service_type_capacity_modeled: int
     service_type_code: str
     infrastructure_type: str
+    service_type_properties: dict[str, Any]
     territory_type_id: int | None
     territory_type_name: str | None
     name: str | None
@@ -36,6 +37,7 @@ class ServiceWithGeometryDTO:  # pylint: disable=too-many-instance-attributes
     service_type_capacity_modeled: int
     service_type_code: str
     infrastructure_type: str
+    service_type_properties: dict[str, Any]
     territory_type_id: int | None
     territory_type_name: str | None
     name: str | None
@@ -74,6 +76,7 @@ class ServiceWithGeometryDTO:  # pylint: disable=too-many-instance-attributes
             "capacity_modeled": service.pop("service_type_capacity_modeled", None),
             "code": service.pop("service_type_code", None),
             "infrastructure_type": service.pop("infrastructure_type", None),
+            "properties": service.pop("service_type_properties", None),
         }
         service["service_type"] = service_type
 
@@ -90,6 +93,7 @@ class ServiceWithTerritoriesDTO:  # pylint: disable=too-many-instance-attributes
     service_type_capacity_modeled: int
     service_type_code: str
     infrastructure_type: str
+    service_type_properties: dict[str, Any]
     territory_type_id: int | None
     territory_type_name: str | None
     name: str | None

--- a/idu_api/urban_api/dto/territories.py
+++ b/idu_api/urban_api/dto/territories.py
@@ -22,9 +22,7 @@ class TerritoryTypeDTO:
 
 @dataclass
 class TerritoryDTO:  # pylint: disable=too-many-instance-attributes
-    """
-    Territory DTO used to transfer territory data
-    """
+    """Territory DTO used to transfer territory data."""
 
     territory_id: int
     territory_type_id: int
@@ -59,9 +57,7 @@ class TerritoryDTO:  # pylint: disable=too-many-instance-attributes
 
 @dataclass(frozen=True)
 class TerritoryWithoutGeometryDTO:  # pylint: disable=too-many-instance-attributes
-    """
-    Territory DTO used to transfer territory data without geometry
-    """
+    """Territory DTO used to transfer territory data without geometry."""
 
     territory_id: int
     territory_type_id: int
@@ -79,9 +75,7 @@ class TerritoryWithoutGeometryDTO:  # pylint: disable=too-many-instance-attribut
 
 @dataclass
 class TerritoryWithIndicatorDTO:
-    """
-    Territory DTO used to transfer short territory data with indicator
-    """
+    """Territory DTO used to transfer short territory data with indicator."""
 
     geometry: geom.Polygon | geom.MultiPolygon | geom.Point
     centre_point: geom.Point
@@ -105,9 +99,7 @@ class TerritoryWithIndicatorDTO:
 
 @dataclass
 class TerritoryWithIndicatorsDTO:
-    """
-    Territory DTO used to transfer short territory data with list of indicators
-    """
+    """Territory DTO used to transfer short territory data with list of indicators."""
 
     geometry: geom.Polygon | geom.MultiPolygon | geom.Point
     centre_point: geom.Point
@@ -137,9 +129,7 @@ class TerritoryWithIndicatorsDTO:
 
 @dataclass
 class TerritoryWithNormativesDTO:
-    """
-    Territory DTO used to transfer short territory data with list of indicators
-    """
+    """Territory DTO used to transfer short territory data with list of indicators."""
 
     geometry: geom.Polygon | geom.MultiPolygon | geom.Point
     centre_point: geom.Point

--- a/idu_api/urban_api/dto/urban_objects.py
+++ b/idu_api/urban_api/dto/urban_objects.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import shapely.geometry as geom
 
@@ -11,6 +11,8 @@ class UrbanObjectDTO:  # pylint: disable=too-many-instance-attributes
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
+    physical_object_function_id: int
+    physical_object_function_name: str
     physical_object_name: str | None
     physical_object_properties: dict[str, Any]
     physical_object_created_at: datetime
@@ -31,11 +33,12 @@ class UrbanObjectDTO:  # pylint: disable=too-many-instance-attributes
     service_type_capacity_modeled: int | None
     service_type_code: str | None
     infrastructure_type: str | None
+    service_type_properties: dict[str, Any] | None
     territory_type_id: int | None
     territory_type_name: str | None
     service_name: str | None
     capacity_real: int | None
-    service_properties: Optional[dict[str, Any]]
+    service_properties: dict[str, Any] | None
     service_created_at: datetime | None
     service_updated_at: datetime | None
 

--- a/idu_api/urban_api/dto/urban_objects.py
+++ b/idu_api/urban_api/dto/urban_objects.py
@@ -11,8 +11,8 @@ class UrbanObjectDTO:  # pylint: disable=too-many-instance-attributes
     physical_object_id: int
     physical_object_type_id: int
     physical_object_type_name: str
-    physical_object_function_id: int
-    physical_object_function_name: str
+    physical_object_function_id: int | None
+    physical_object_function_name: str | None
     physical_object_name: str | None
     physical_object_properties: dict[str, Any]
     physical_object_created_at: datetime

--- a/idu_api/urban_api/fastapi_init.py
+++ b/idu_api/urban_api/fastapi_init.py
@@ -12,6 +12,7 @@ from idu_api.urban_api.config import UrbanAPIConfig
 from idu_api.urban_api.logic.impl.functional_zones import FunctionalZonesServiceImpl
 from idu_api.urban_api.logic.impl.indicators import IndicatorsServiceImpl
 from idu_api.urban_api.logic.impl.object_geometries import ObjectGeometriesServiceImpl
+from idu_api.urban_api.logic.impl.physical_object_types import PhysicalObjectTypesServiceImpl
 from idu_api.urban_api.logic.impl.physical_objects import PhysicalObjectsServiceImpl
 from idu_api.urban_api.logic.impl.projects import UserProjectServiceImpl
 from idu_api.urban_api.logic.impl.service_types import ServiceTypesServiceImpl
@@ -83,6 +84,7 @@ def get_app(prefix: str = "/api") -> FastAPI:
         functional_zones_service=FunctionalZonesServiceImpl,
         indicators_service=IndicatorsServiceImpl,
         object_geometries_service=ObjectGeometriesServiceImpl,
+        physical_object_types_service=PhysicalObjectTypesServiceImpl,
         physical_objects_service=PhysicalObjectsServiceImpl,
         service_types_service=ServiceTypesServiceImpl,
         services_data_service=ServicesDataServiceImpl,

--- a/idu_api/urban_api/handlers/v1/physical_object_types.py
+++ b/idu_api/urban_api/handlers/v1/physical_object_types.py
@@ -1,0 +1,208 @@
+"""Physical object type handlers are defined here."""
+
+from fastapi import Path, Query, Request
+from starlette import status
+
+from idu_api.urban_api.logic.physical_object_types import PhysicalObjectTypesService
+from idu_api.urban_api.schemas import (
+    PhysicalObjectFunction,
+    PhysicalObjectFunctionPatch,
+    PhysicalObjectFunctionPost,
+    PhysicalObjectFunctionPut,
+    PhysicalObjectsTypes,
+    PhysicalObjectsTypesHierarchy,
+    PhysicalObjectsTypesPatch,
+    PhysicalObjectsTypesPost,
+)
+
+from .routers import physical_object_types_router
+
+
+@physical_object_types_router.get(
+    "/physical_object_types",
+    response_model=list[PhysicalObjectsTypes],
+    status_code=status.HTTP_200_OK,
+)
+async def get_physical_object_types(request: Request) -> list[PhysicalObjectsTypes]:
+    """Get all physical object types."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    physical_object_types = await physical_object_types_service.get_physical_object_types()
+
+    return [PhysicalObjectsTypes.from_dto(object_type) for object_type in physical_object_types]
+
+
+@physical_object_types_router.post(
+    "/physical_object_types",
+    response_model=PhysicalObjectsTypes,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_physical_object_type(
+    request: Request, physical_object_type: PhysicalObjectsTypesPost
+) -> PhysicalObjectsTypes:
+    """Add a physical object type."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    physical_object_type_dto = await physical_object_types_service.add_physical_object_type(physical_object_type)
+
+    return PhysicalObjectsTypes.from_dto(physical_object_type_dto)
+
+
+@physical_object_types_router.patch(
+    "/physical_object_types/{physical_object_type_id}",
+    response_model=PhysicalObjectsTypes,
+    status_code=status.HTTP_200_OK,
+)
+async def patch_physical_object_type(
+    request: Request,
+    physical_object_type: PhysicalObjectsTypesPatch,
+    physical_object_type_id: int = Path(..., description="physical object type identifier"),
+) -> PhysicalObjectsTypes:
+    """Update physical object type by only given attributes."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    physical_object_type_dto = await physical_object_types_service.patch_physical_object_type(
+        physical_object_type_id, physical_object_type
+    )
+
+    return PhysicalObjectsTypes.from_dto(physical_object_type_dto)
+
+
+@physical_object_types_router.delete(
+    "/physical_object_types/{physical_object_type_id}",
+    response_model=dict,
+    status_code=status.HTTP_200_OK,
+)
+async def delete_physical_object_type(
+    request: Request, physical_object_type_id: int = Path(..., description="physical object type identifier")
+) -> dict:
+    """Delete physical object type by id."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    return await physical_object_types_service.delete_physical_object_type(physical_object_type_id)
+
+
+@physical_object_types_router.get(
+    "/physical_object_functions_by_parent",
+    response_model=list[PhysicalObjectFunction],
+    status_code=status.HTTP_200_OK,
+)
+async def get_physical_object_functions_by_parent_id(
+    request: Request,
+    parent_id: int | None = Query(
+        None,
+        description="parent physical object function id to filter, "
+        "should be skipped for top level physical object functions",
+    ),
+    name: str | None = Query(None, description="search by physical object function name"),
+    get_all_subtree: bool = Query(False, description="getting full subtree of physical object functions"),
+) -> list[PhysicalObjectFunction]:
+    """Get physical object functions by parent id (skip it to get upper level)."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    physical_object_functions = await physical_object_types_service.get_physical_object_functions_by_parent_id(
+        parent_id, name, get_all_subtree
+    )
+
+    return [
+        PhysicalObjectFunction.from_dto(physical_object_function)
+        for physical_object_function in physical_object_functions
+    ]
+
+
+@physical_object_types_router.post(
+    "/physical_object_functions",
+    response_model=PhysicalObjectFunction,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_physical_object_function(
+    request: Request, physical_object_function: PhysicalObjectFunctionPost
+) -> PhysicalObjectFunction:
+    """Add a new physical object function."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    physical_object_function_dto = await physical_object_types_service.add_physical_object_function(
+        physical_object_function
+    )
+
+    return PhysicalObjectFunction.from_dto(physical_object_function_dto)
+
+
+@physical_object_types_router.put(
+    "/physical_object_functions/{physical_object_function_id}",
+    response_model=PhysicalObjectFunction,
+    status_code=status.HTTP_200_OK,
+)
+async def put_physical_object_function(
+    request: Request,
+    physical_object_function: PhysicalObjectFunctionPut,
+    physical_object_function_id: int = Path(..., description="physical object function identifier"),
+) -> PhysicalObjectFunction:
+    """Update physical object function by all its attributes."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    physical_object_function_dto = await physical_object_types_service.put_physical_object_function(
+        physical_object_function_id, physical_object_function
+    )
+
+    return PhysicalObjectFunction.from_dto(physical_object_function_dto)
+
+
+@physical_object_types_router.patch(
+    "/physical_object_functions/{physical_object_function_id}",
+    response_model=PhysicalObjectFunction,
+    status_code=status.HTTP_200_OK,
+)
+async def patch_physical_object_function(
+    request: Request,
+    physical_object_function: PhysicalObjectFunctionPatch,
+    physical_object_function_id: int = Path(..., description="physical object function identifier"),
+) -> PhysicalObjectFunction:
+    """Update physical object function by only given attributes."""
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    physical_object_function_dto = await physical_object_types_service.patch_physical_object_function(
+        physical_object_function_id, physical_object_function
+    )
+
+    return PhysicalObjectFunction.from_dto(physical_object_function_dto)
+
+
+@physical_object_types_router.delete(
+    "/physical_object_functions/{physical_object_function_id}",
+    response_model=dict,
+    status_code=status.HTTP_200_OK,
+)
+async def delete_physical_object_function(
+    request: Request, physical_object_function_id: int = Path(..., description="physical object function identifier")
+) -> dict:
+    """Delete physical object function by id.
+
+    It also removes all child elements of this physical object function!!!
+    """
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    return await physical_object_types_service.delete_physical_object_function(physical_object_function_id)
+
+
+@physical_object_types_router.get(
+    "/physical_object_types/hierarchy",
+    response_model=list[PhysicalObjectsTypesHierarchy],
+    status_code=status.HTTP_200_OK,
+)
+async def get_physical_object_types_hierarchy(
+    request: Request,
+    physical_object_types_ids: str | None = Query(
+        None, description="list of physical object type ids separated by comma"
+    ),
+) -> list[PhysicalObjectsTypesHierarchy]:
+    """Get physical object types hierarchy (from top-level physical object function to physical object type
+    based on a list of required physical object type ids.
+
+    If the list of identifiers was not passed, it returns the full hierarchy.
+    """
+    physical_object_types_service: PhysicalObjectTypesService = request.state.physical_object_types_service
+
+    hierarchy = await physical_object_types_service.get_physical_object_types_hierarchy(physical_object_types_ids)
+
+    return [PhysicalObjectsTypesHierarchy.from_dto(node) for node in hierarchy]

--- a/idu_api/urban_api/handlers/v1/physical_objects.py
+++ b/idu_api/urban_api/handlers/v1/physical_objects.py
@@ -14,8 +14,6 @@ from idu_api.urban_api.schemas import (
     PhysicalObjectsDataPatch,
     PhysicalObjectsDataPost,
     PhysicalObjectsDataPut,
-    PhysicalObjectsTypes,
-    PhysicalObjectsTypesPost,
     PhysicalObjectsWithTerritory,
     PhysicalObjectWithGeometryPost,
     ServicesData,
@@ -26,36 +24,6 @@ from idu_api.urban_api.schemas.physical_objects import PhysicalObjectWithGeometr
 from idu_api.urban_api.schemas.urban_objects import UrbanObject
 
 from .routers import physical_objects_router
-
-
-@physical_objects_router.get(
-    "/physical_object_types",
-    response_model=list[PhysicalObjectsTypes],
-    status_code=status.HTTP_200_OK,
-)
-async def get_physical_object_types(request: Request) -> list[PhysicalObjectsTypes]:
-    """Get all physical object types."""
-    physical_objects_service: PhysicalObjectsService = request.state.physical_objects_service
-
-    physical_object_types = await physical_objects_service.get_physical_object_types()
-
-    return [PhysicalObjectsTypes.from_dto(object_type) for object_type in physical_object_types]
-
-
-@physical_objects_router.post(
-    "/physical_object_types",
-    response_model=PhysicalObjectsTypes,
-    status_code=status.HTTP_201_CREATED,
-)
-async def add_physical_object_type(
-    request: Request, physical_object_type: PhysicalObjectsTypesPost
-) -> PhysicalObjectsTypes:
-    """Add a physical object type."""
-    physical_objects_service: PhysicalObjectsService = request.state.physical_objects_service
-
-    physical_object_type_dto = await physical_objects_service.add_physical_object_type(physical_object_type)
-
-    return PhysicalObjectsTypes.from_dto(physical_object_type_dto)
 
 
 @physical_objects_router.post(

--- a/idu_api/urban_api/handlers/v1/routers.py
+++ b/idu_api/urban_api/handlers/v1/routers.py
@@ -14,6 +14,8 @@ service_types_router = APIRouter(tags=["service_types"], prefix="/v1")
 
 functional_zones_router = APIRouter(tags=["functional_zones"], prefix="/v1")
 
+physical_object_types_router = APIRouter(tags=["physical_object_types"], prefix="/v1")
+
 physical_objects_router = APIRouter(tags=["physical_objects"], prefix="/v1")
 
 object_geometries_router = APIRouter(tags=["object_geometries"], prefix="/v1")
@@ -26,6 +28,7 @@ routers_list = [
     indicators_router,
     services_router,
     functional_zones_router,
+    physical_object_types_router,
     physical_objects_router,
     object_geometries_router,
     service_types_router,

--- a/idu_api/urban_api/handlers/v1/service_types.py
+++ b/idu_api/urban_api/handlers/v1/service_types.py
@@ -113,7 +113,7 @@ async def get_urban_functions_by_parent_id(
     name: str | None = Query(None, description="Search by urban function name"),
     get_all_subtree: bool = Query(False, description="Getting full subtree of urban functions"),
 ) -> list[UrbanFunction]:
-    """Get indicators by parent id (skip it to get upper level)."""
+    """Get urban functions by parent id (skip it to get upper level)."""
     service_types_service: ServiceTypesService = request.state.service_types_service
 
     urban_functions = await service_types_service.get_urban_functions_by_parent_id(parent_id, name, get_all_subtree)

--- a/idu_api/urban_api/logic/impl/helpers/object_geometries.py
+++ b/idu_api/urban_api/logic/impl/helpers/object_geometries.py
@@ -56,7 +56,7 @@ async def get_physical_objects_by_object_geometry_id_from_db(
                 physical_object_types_dict,
                 physical_object_types_dict.c.physical_object_type_id == physical_objects_data.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,

--- a/idu_api/urban_api/logic/impl/helpers/object_geometries.py
+++ b/idu_api/urban_api/logic/impl/helpers/object_geometries.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 from idu_api.common.db.entities import (
     object_geometries_data,
+    physical_object_functions_dict,
     physical_object_types_dict,
     physical_objects_data,
     territories_data,
@@ -41,6 +42,8 @@ async def get_physical_objects_by_object_geometry_id_from_db(
             physical_objects_data.c.properties,
             physical_object_types_dict.c.physical_object_type_id,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_functions_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
             physical_objects_data.c.created_at,
             physical_objects_data.c.updated_at,
         )
@@ -52,6 +55,11 @@ async def get_physical_objects_by_object_geometry_id_from_db(
             .join(
                 physical_object_types_dict,
                 physical_object_types_dict.c.physical_object_type_id == physical_objects_data.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
             .join(
                 object_geometries_data,

--- a/idu_api/urban_api/logic/impl/helpers/physical_object_types.py
+++ b/idu_api/urban_api/logic/impl/helpers/physical_object_types.py
@@ -28,7 +28,7 @@ async def get_physical_object_types_from_db(conn: AsyncConnection) -> list[Physi
     statement = (
         select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
         .select_from(
-            physical_object_types_dict.join(
+            physical_object_types_dict.outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -71,7 +71,7 @@ async def add_physical_object_type_to_db(
     statement = (
         select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
         .select_from(
-            physical_object_types_dict.join(
+            physical_object_types_dict.outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -133,7 +133,7 @@ async def patch_physical_object_type_to_db(
     statement = (
         select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
         .select_from(
-            physical_object_types_dict.join(
+            physical_object_types_dict.outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -431,7 +431,7 @@ async def get_physical_object_types_hierarchy_from_db(
     statement = (
         select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
         .select_from(
-            physical_object_types_dict.join(
+            physical_object_types_dict.outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,

--- a/idu_api/urban_api/logic/impl/helpers/physical_object_types.py
+++ b/idu_api/urban_api/logic/impl/helpers/physical_object_types.py
@@ -1,0 +1,478 @@
+"""Physical objects types handlers logic of getting entities from the database is defined here."""
+
+from sqlalchemy import delete, insert, select, update
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from idu_api.common.db.entities import (
+    physical_object_functions_dict,
+    physical_object_types_dict,
+)
+from idu_api.urban_api.dto import (
+    PhysicalObjectFunctionDTO,
+    PhysicalObjectTypeDTO,
+    PhysicalObjectTypesHierarchyDTO,
+)
+from idu_api.urban_api.exceptions.logic.common import EntitiesNotFoundByIds, EntityAlreadyExists, EntityNotFoundById
+from idu_api.urban_api.schemas import (
+    PhysicalObjectFunctionPatch,
+    PhysicalObjectFunctionPost,
+    PhysicalObjectFunctionPut,
+    PhysicalObjectsTypesPatch,
+    PhysicalObjectsTypesPost,
+)
+
+
+async def get_physical_object_types_from_db(conn: AsyncConnection) -> list[PhysicalObjectTypeDTO]:
+    """Get all physical object type objects."""
+
+    statement = (
+        select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
+        .select_from(
+            physical_object_types_dict.join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
+            )
+        )
+        .order_by(physical_object_types_dict.c.physical_object_type_id)
+    )
+
+    return [PhysicalObjectTypeDTO(**data) for data in (await conn.execute(statement)).mappings().all()]
+
+
+async def add_physical_object_type_to_db(
+    conn: AsyncConnection,
+    physical_object_type: PhysicalObjectsTypesPost,
+) -> PhysicalObjectTypeDTO:
+    """Create physical object type object."""
+
+    statement = select(physical_object_types_dict).where(physical_object_types_dict.c.name == physical_object_type.name)
+    result = (await conn.execute(statement)).one_or_none()
+    if result is not None:
+        raise EntityAlreadyExists("physical object type", physical_object_type.name)
+
+    statement = select(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.physical_object_function_id == physical_object_type.physical_object_function_id
+    )
+    result = (await conn.execute(statement)).one_or_none()
+    if result is None:
+        raise EntityAlreadyExists("physical object function", physical_object_type.physical_object_function_id)
+
+    statement = (
+        insert(physical_object_types_dict)
+        .values(
+            name=physical_object_type.name,
+            physical_object_function_id=physical_object_type.physical_object_function_id,
+        )
+        .returning(physical_object_types_dict.c.physical_object_type_id)
+    )
+    result_id = (await conn.execute(statement)).scalar_one()
+
+    statement = (
+        select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
+        .select_from(
+            physical_object_types_dict.join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
+            )
+        )
+        .where(physical_object_types_dict.c.physical_object_type_id == result_id)
+    )
+
+    result = (await conn.execute(statement)).mappings().one()
+
+    await conn.commit()
+
+    return PhysicalObjectTypeDTO(**result)
+
+
+async def patch_physical_object_type_to_db(
+    conn: AsyncConnection,
+    physical_object_type_id: int,
+    physical_object_type: PhysicalObjectsTypesPatch,
+) -> PhysicalObjectTypeDTO:
+    """Update physical object type object by only given attributes."""
+
+    statement = select(physical_object_types_dict).where(
+        physical_object_types_dict.c.physical_object_type_id == physical_object_type_id
+    )
+    result = (await conn.execute(statement)).one_or_none()
+    if result is None:
+        raise EntityNotFoundById(physical_object_type_id, "physical object type")
+
+    if physical_object_type.physical_object_function_id is not None:
+        statement = select(physical_object_functions_dict).where(
+            physical_object_functions_dict.c.physical_object_function_id
+            == physical_object_type.physical_object_function_id
+        )
+        result = (await conn.execute(statement)).one_or_none()
+        if result is None:
+            raise EntityNotFoundById(physical_object_type.physical_object_function_id, "physical object function")
+
+    if physical_object_type.name is not None:
+        statement = select(physical_object_types_dict).where(
+            physical_object_types_dict.c.name == physical_object_type.name,
+            physical_object_types_dict.c.physical_object_type_id != physical_object_type_id,
+        )
+        result = (await conn.execute(statement)).one_or_none()
+        if result is not None:
+            raise EntityAlreadyExists("physical object type", physical_object_type.name)
+
+    statement = update(physical_object_types_dict).where(
+        physical_object_types_dict.c.physical_object_type_id == physical_object_type_id
+    )
+
+    values_to_update = {}
+    for k, v in physical_object_type.model_dump(exclude_unset=True).items():
+        values_to_update.update({k: v})
+
+    statement = statement.values(**values_to_update)
+    await conn.execute(statement)
+
+    statement = (
+        select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
+        .select_from(
+            physical_object_types_dict.join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
+            )
+        )
+        .where(physical_object_types_dict.c.physical_object_type_id == physical_object_type_id)
+    )
+    result = (await conn.execute(statement)).mappings().one()
+
+    await conn.commit()
+
+    return PhysicalObjectTypeDTO(**result)
+
+
+async def delete_physical_object_type_from_db(conn: AsyncConnection, physical_object_type_id: int) -> dict:
+    """Delete physical object type object by id."""
+
+    statement = select(physical_object_types_dict).where(
+        physical_object_types_dict.c.physical_object_type_id == physical_object_type_id
+    )
+    physical_object_type = (await conn.execute(statement)).scalar_one_or_none()
+    if physical_object_type is None:
+        raise EntityNotFoundById(physical_object_type_id, "physical object type")
+
+    statement = delete(physical_object_types_dict).where(
+        physical_object_types_dict.c.physical_object_type_id == physical_object_type_id
+    )
+    await conn.execute(statement)
+    await conn.commit()
+
+    return {"result": "ok"}
+
+
+async def get_physical_object_functions_by_parent_id_from_db(
+    conn: AsyncConnection,
+    parent_id: int | None,
+    name: str | None,
+    get_all_subtree: bool,
+) -> list[PhysicalObjectFunctionDTO]:
+    """Get a physical object function or list of physical object functions by parent."""
+
+    if parent_id is not None:
+        statement = select(physical_object_functions_dict).where(
+            physical_object_functions_dict.c.physical_object_function_id == parent_id
+        )
+        parent_physical_object_function = (await conn.execute(statement)).one_or_none()
+        if parent_physical_object_function is None:
+            raise EntityNotFoundById(parent_id, "physical object function")
+
+    physical_object_functions_parents = physical_object_functions_dict.alias("physical_object_functions_parents")
+    statement = select(
+        physical_object_functions_dict, physical_object_functions_parents.c.name.label("parent_name")
+    ).select_from(
+        physical_object_functions_dict.outerjoin(
+            physical_object_functions_parents,
+            physical_object_functions_parents.c.physical_object_function_id
+            == physical_object_functions_dict.c.parent_id,
+        ),
+    )
+
+    if get_all_subtree:
+        cte_statement = statement.where(
+            physical_object_functions_dict.c.parent_id == parent_id
+            if parent_id is not None
+            else physical_object_functions_dict.c.parent_id.is_(None)
+        )
+        cte_statement = cte_statement.cte(name="physical_object_function_recursive", recursive=True)
+
+        recursive_part = statement.join(
+            cte_statement,
+            physical_object_functions_dict.c.parent_id == cte_statement.c.physical_object_function_id,
+        )
+
+        statement = select(cte_statement.union_all(recursive_part))
+    else:
+        statement = statement.where(
+            physical_object_functions_dict.c.parent_id == parent_id
+            if parent_id is not None
+            else physical_object_functions_dict.c.parent_id.is_(None)
+        )
+
+    requested_physical_object_functions = statement.cte("requested_physical_object_functions")
+
+    statement = select(requested_physical_object_functions)
+
+    if name is not None:
+        statement = statement.where(requested_physical_object_functions.c.name.ilike(f"%{name}%"))
+
+    result = (await conn.execute(statement)).mappings().all()
+
+    return [PhysicalObjectFunctionDTO(**physical_object_function) for physical_object_function in result]
+
+
+async def add_physical_object_function_to_db(
+    conn: AsyncConnection,
+    physical_object_function: PhysicalObjectFunctionPost,
+) -> PhysicalObjectFunctionDTO:
+    """Create physical object function object."""
+
+    if physical_object_function.parent_id is not None:
+        statement = select(physical_object_functions_dict).where(
+            physical_object_functions_dict.c.physical_object_function_id == physical_object_function.parent_id
+        )
+        parent_physical_object_function = (await conn.execute(statement)).one_or_none()
+        if parent_physical_object_function is None:
+            raise EntityNotFoundById(physical_object_function.parent_id, "physical object function")
+
+    statement = select(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.name == physical_object_function.name
+    )
+    physical_object_function_name = (await conn.execute(statement)).one_or_none()
+    if physical_object_function_name is not None:
+        raise EntityAlreadyExists("physical object function", physical_object_function.name)
+
+    statement = (
+        insert(physical_object_functions_dict)
+        .values(
+            parent_id=physical_object_function.parent_id,
+            name=physical_object_function.name,
+            code=physical_object_function.code,
+        )
+        .returning(physical_object_functions_dict.c.physical_object_function_id)
+    )
+    physical_object_function_id = (await conn.execute(statement)).scalar_one()
+
+    physical_object_functions_parents = physical_object_functions_dict.alias("physical_object_functions_parents")
+    statement = (
+        select(physical_object_functions_dict, physical_object_functions_parents.c.name.label("parent_name"))
+        .select_from(
+            physical_object_functions_dict.outerjoin(
+                physical_object_functions_parents,
+                physical_object_functions_parents.c.physical_object_function_id
+                == physical_object_functions_dict.c.parent_id,
+            ),
+        )
+        .where(physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id)
+    )
+    result = (await conn.execute(statement)).mappings().one()
+
+    await conn.commit()
+
+    return PhysicalObjectFunctionDTO(**result)
+
+
+async def put_physical_object_function_to_db(
+    conn: AsyncConnection,
+    physical_object_function_id: int,
+    physical_object_function: PhysicalObjectFunctionPut,
+) -> PhysicalObjectFunctionDTO:
+    """Update physical object function object by getting all its attributes."""
+
+    statement = select(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id
+    )
+    result = (await conn.execute(statement)).one_or_none()
+    if result is None:
+        raise EntityNotFoundById(physical_object_function_id, "physical object function")
+
+    if physical_object_function.parent_id is not None:
+        statement = select(physical_object_functions_dict).where(
+            physical_object_functions_dict.c.physical_object_function_id == physical_object_function.parent_id
+        )
+        result = (await conn.execute(statement)).one_or_none()
+        if result is None:
+            raise EntityNotFoundById(physical_object_function.parent_id, "physical object function")
+
+    statement = select(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.name == physical_object_function.name,
+        physical_object_functions_dict.c.physical_object_function_id != physical_object_function_id,
+    )
+    result = (await conn.execute(statement)).one_or_none()
+    if result is not None:
+        raise EntityAlreadyExists("physical object function", physical_object_function.name)
+
+    statement = (
+        update(physical_object_functions_dict)
+        .where(physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id)
+        .values(
+            name=physical_object_function.name,
+            parent_id=physical_object_function.parent_id,
+            code=physical_object_function.code,
+        )
+    )
+
+    await conn.execute(statement)
+
+    physical_object_functions_parents = physical_object_functions_dict.alias("physical_object_functions_parents")
+    statement = (
+        select(physical_object_functions_dict, physical_object_functions_parents.c.name.label("parent_name"))
+        .select_from(
+            physical_object_functions_dict.outerjoin(
+                physical_object_functions_parents,
+                physical_object_functions_parents.c.physical_object_function_id
+                == physical_object_functions_dict.c.parent_id,
+            ),
+        )
+        .where(physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id)
+    )
+    result = (await conn.execute(statement)).mappings().one()
+
+    await conn.commit()
+
+    return PhysicalObjectFunctionDTO(**result)
+
+
+async def patch_physical_object_function_to_db(
+    conn: AsyncConnection,
+    physical_object_function_id: int,
+    physical_object_function: PhysicalObjectFunctionPatch,
+) -> PhysicalObjectFunctionDTO:
+    """Update physical object function object by getting only given attributes."""
+
+    statement = select(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id
+    )
+    result = (await conn.execute(statement)).one_or_none()
+    if result is None:
+        raise EntityNotFoundById(physical_object_function_id, "physical object function")
+
+    if physical_object_function.parent_id is not None:
+        statement = select(physical_object_functions_dict).where(
+            physical_object_functions_dict.c.physical_object_function_id == physical_object_function.parent_id
+        )
+        result = (await conn.execute(statement)).one_or_none()
+        if result is None:
+            raise EntityNotFoundById(physical_object_function.parent_id, "physical object function")
+
+    if physical_object_function.name is not None:
+        statement = select(physical_object_functions_dict).where(
+            physical_object_functions_dict.c.name == physical_object_function.name,
+            physical_object_functions_dict.c.physical_object_function_id != physical_object_function_id,
+        )
+        result = (await conn.execute(statement)).one_or_none()
+        if result is not None:
+            raise EntityAlreadyExists("physical object function", physical_object_function.name)
+
+    statement = update(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id
+    )
+
+    values_to_update = {}
+    for k, v in physical_object_function.model_dump(exclude_unset=True).items():
+        values_to_update.update({k: v})
+
+    statement = statement.values(**values_to_update)
+    await conn.execute(statement)
+
+    physical_object_functions_parents = physical_object_functions_dict.alias("physical_object_functions_parents")
+    statement = (
+        select(physical_object_functions_dict, physical_object_functions_parents.c.name.label("parent_name"))
+        .select_from(
+            physical_object_functions_dict.outerjoin(
+                physical_object_functions_parents,
+                physical_object_functions_parents.c.physical_object_function_id
+                == physical_object_functions_dict.c.parent_id,
+            ),
+        )
+        .where(physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id)
+    )
+    result = (await conn.execute(statement)).mappings().one()
+
+    await conn.commit()
+
+    return PhysicalObjectFunctionDTO(**result)
+
+
+async def delete_physical_object_function_from_db(conn: AsyncConnection, physical_object_function_id: int) -> dict:
+    """Delete physical object function object by id."""
+
+    statement = select(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id
+    )
+    physical_object_function = (await conn.execute(statement)).scalar_one_or_none()
+    if physical_object_function is None:
+        raise EntityNotFoundById(physical_object_function_id, "physical object function")
+
+    statement = delete(physical_object_functions_dict).where(
+        physical_object_functions_dict.c.physical_object_function_id == physical_object_function_id
+    )
+    await conn.execute(statement)
+    await conn.commit()
+
+    return {"result": "ok"}
+
+
+async def get_physical_object_types_hierarchy_from_db(
+    conn: AsyncConnection, physical_object_type_ids: str | None
+) -> list[PhysicalObjectTypesHierarchyDTO]:
+    """Get physical object types hierarchy (from top-level physical object function to physical object type)
+    based on a list of required physical object type ids.
+
+    If the list of identifiers was not passed, it returns the full hierarchy.
+    """
+
+    statement = (
+        select(physical_object_types_dict, physical_object_functions_dict.c.name.label("physical_object_function_name"))
+        .select_from(
+            physical_object_types_dict.join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
+            )
+        )
+        .order_by(physical_object_types_dict.c.physical_object_type_id)
+    )
+
+    if physical_object_type_ids is not None:
+        ids = [int(physical_object_type_id.strip()) for physical_object_type_id in physical_object_type_ids.split(",")]
+        query = select(physical_object_types_dict.c.physical_object_type_id).where(
+            physical_object_types_dict.c.physical_object_type_id.in_(ids)
+        )
+        physical_object_types = (await conn.execute(query)).scalars().all()
+        if len(list(physical_object_types)) < len(ids):
+            raise EntitiesNotFoundByIds("physical object type")
+        statement = statement.where(physical_object_types_dict.c.physical_object_type_id.in_(ids))
+
+    physical_object_types = (await conn.execute(statement)).mappings().all()
+
+    statement = select(physical_object_functions_dict).order_by(physical_object_functions_dict.c.level)
+    physical_object_functions = (await conn.execute(statement)).mappings().all()
+
+    def build_filtered_hierarchy(parent_id: int = None) -> list[PhysicalObjectTypesHierarchyDTO]:
+        children = []
+        for pof in [pof for pof in physical_object_functions if pof.parent_id == parent_id]:
+            filtered_children = build_filtered_hierarchy(pof.physical_object_function_id)
+
+            relevant_physical_object_types = [
+                PhysicalObjectTypeDTO(**p)
+                for p in physical_object_types
+                if p.physical_object_function_id == pof.physical_object_function_id
+            ]
+
+            if filtered_children or relevant_physical_object_types:
+                children.append(
+                    PhysicalObjectTypesHierarchyDTO(
+                        **pof, children=filtered_children if filtered_children else relevant_physical_object_types
+                    )
+                )
+
+        return children
+
+    return build_filtered_hierarchy()

--- a/idu_api/urban_api/logic/impl/helpers/physical_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/physical_objects.py
@@ -87,7 +87,7 @@ async def get_physical_objects_by_ids_from_db(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -188,7 +188,7 @@ async def get_physical_object_by_id_from_db(conn: AsyncConnection, physical_obje
             physical_objects_data.join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
-            ).join(
+            ).outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -370,7 +370,7 @@ async def get_living_building_by_id_from_db(conn: AsyncConnection, living_buildi
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -544,7 +544,7 @@ async def get_living_buildings_by_physical_object_id_from_db(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -775,7 +775,7 @@ async def get_physical_object_with_territories_by_id_from_db(
             physical_objects_data.join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
-            ).join(
+            ).outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,

--- a/idu_api/urban_api/logic/impl/helpers/physical_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/physical_objects.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from idu_api.common.db.entities import (
     living_buildings_data,
     object_geometries_data,
+    physical_object_functions_dict,
     physical_object_types_dict,
     physical_objects_data,
     service_types_dict,
@@ -26,7 +27,6 @@ from idu_api.urban_api.dto import (
     LivingBuildingsDTO,
     ObjectGeometryDTO,
     PhysicalObjectDataDTO,
-    PhysicalObjectTypeDTO,
     PhysicalObjectWithGeometryDTO,
     PhysicalObjectWithTerritoryDTO,
     ServiceDTO,
@@ -35,7 +35,6 @@ from idu_api.urban_api.dto import (
 )
 from idu_api.urban_api.exceptions.logic.common import (
     EntitiesNotFoundByIds,
-    EntityAlreadyExists,
     EntityNotFoundById,
     TooManyObjectsError,
 )
@@ -47,7 +46,6 @@ from idu_api.urban_api.schemas import (
     PhysicalObjectsDataPatch,
     PhysicalObjectsDataPost,
     PhysicalObjectsDataPut,
-    PhysicalObjectsTypesPost,
     PhysicalObjectWithGeometryPost,
 )
 
@@ -69,6 +67,8 @@ async def get_physical_objects_by_ids_from_db(
         select(
             physical_objects_data,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
             object_geometries_data.c.address,
             object_geometries_data.c.osm_id,
             cast(ST_AsGeoJSON(object_geometries_data.c.geometry), JSONB).label("geometry"),
@@ -86,6 +86,11 @@ async def get_physical_objects_by_ids_from_db(
             .join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
         )
         .where(physical_objects_data.c.physical_object_id.in_(ids))
@@ -169,39 +174,6 @@ async def get_physical_objects_around_from_db(
     return await get_physical_objects_by_ids_from_db(conn, ids)
 
 
-async def get_physical_object_types_from_db(conn: AsyncConnection) -> list[PhysicalObjectTypeDTO]:
-    """Get all physical object type objects."""
-
-    statement = select(physical_object_types_dict).order_by(physical_object_types_dict.c.physical_object_type_id)
-
-    return [PhysicalObjectTypeDTO(**data) for data in (await conn.execute(statement)).mappings().all()]
-
-
-async def add_physical_object_type_to_db(
-    conn: AsyncConnection,
-    physical_object_type: PhysicalObjectsTypesPost,
-) -> PhysicalObjectTypeDTO:
-    """Create physical object type object."""
-
-    statement = select(physical_object_types_dict).where(physical_object_types_dict.c.name == physical_object_type.name)
-    result = (await conn.execute(statement)).one_or_none()
-    if result is not None:
-        raise EntityAlreadyExists("physical object type", physical_object_type.name)
-
-    statement = (
-        insert(physical_object_types_dict)
-        .values(
-            name=physical_object_type.name,
-        )
-        .returning(physical_object_types_dict)
-    )
-    result = (await conn.execute(statement)).mappings().one()
-
-    await conn.commit()
-
-    return PhysicalObjectTypeDTO(**result)
-
-
 async def get_physical_object_by_id_from_db(conn: AsyncConnection, physical_object_id: int) -> PhysicalObjectDataDTO:
     """Get physical object by id."""
 
@@ -209,11 +181,17 @@ async def get_physical_object_by_id_from_db(conn: AsyncConnection, physical_obje
         select(
             physical_objects_data,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
         )
         .select_from(
             physical_objects_data.join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            ).join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
         )
         .where(physical_objects_data.c.physical_object_id == physical_object_id)
@@ -380,6 +358,8 @@ async def get_living_building_by_id_from_db(conn: AsyncConnection, living_buildi
             physical_objects_data.c.updated_at.label("physical_object_updated_at"),
             physical_object_types_dict.c.physical_object_type_id,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_functions_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
         )
         .select_from(
             living_buildings_data.join(
@@ -389,6 +369,11 @@ async def get_living_building_by_id_from_db(conn: AsyncConnection, living_buildi
             .join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
             .join(
                 urban_objects_data,
@@ -547,6 +532,8 @@ async def get_living_buildings_by_physical_object_id_from_db(
             physical_objects_data.c.updated_at.label("physical_object_updated_at"),
             physical_object_types_dict.c.physical_object_type_id,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_functions_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
         )
         .select_from(
             living_buildings_data.join(
@@ -556,6 +543,11 @@ async def get_living_buildings_by_physical_object_id_from_db(
             .join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
             .join(
                 urban_objects_data,
@@ -600,6 +592,7 @@ async def get_services_by_physical_object_id_from_db(
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.name.label("territory_type_name"),
         )
         .select_from(
@@ -652,6 +645,7 @@ async def get_services_with_geometry_by_physical_object_id_from_db(
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.name.label("territory_type_name"),
             object_geometries_data.c.address,
             object_geometries_data.c.osm_id,
@@ -774,11 +768,17 @@ async def get_physical_object_with_territories_by_id_from_db(
         select(
             physical_objects_data,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
         )
         .select_from(
             physical_objects_data.join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            ).join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
         )
         .where(physical_objects_data.c.physical_object_id == physical_object_id)

--- a/idu_api/urban_api/logic/impl/helpers/projects_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_objects.py
@@ -151,6 +151,9 @@ async def add_project_to_db(conn: AsyncConnection, project: ProjectPost, user_id
                         geometry=ST_GeomFromText(str(urban_object.geometry), text("4326")),
                         centre_point=ST_GeomFromText(str(urban_object.centre_point), text("4326")),
                         address=urban_object.address,
+                        osm_id=urban_object.osm_id,
+                        created_at=urban_object.object_geometry_created_at,
+                        updated_at=urban_object.object_geometry_updated_at,
                     )
                     .returning(projects_object_geometries_data.c.object_geometry_id)
                 )

--- a/idu_api/urban_api/logic/impl/helpers/projects_scenarios.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_scenarios.py
@@ -310,6 +310,7 @@ async def add_physical_object_to_scenario_in_db(
             geometry=ST_GeomFromText(str(physical_object.geometry.as_shapely_geometry()), text("4326")),
             centre_point=ST_GeomFromText(str(physical_object.centre_point.as_shapely_geometry()), text("4326")),
             address=physical_object.address,
+            osm_id=physical_object.osm_id,
         )
         .returning(projects_object_geometries_data.c.object_geometry_id)
     )

--- a/idu_api/urban_api/logic/impl/helpers/projects_scenarios_urban_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_scenarios_urban_objects.py
@@ -72,7 +72,7 @@ async def get_scenario_urban_object_by_id_from_db(
                 physical_object_types_dict.c.physical_object_type_id
                 == projects_physical_objects_data.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,

--- a/idu_api/urban_api/logic/impl/helpers/projects_scenarios_urban_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_scenarios_urban_objects.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from idu_api.common.db.entities import (
+    physical_object_functions_dict,
     physical_object_types_dict,
     projects_object_geometries_data,
     projects_physical_objects_data,
@@ -27,6 +28,8 @@ async def get_scenario_urban_object_by_id_from_db(
             projects_urban_objects_data,
             projects_physical_objects_data.c.physical_object_type_id,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
             projects_physical_objects_data.c.name.label("physical_object_name"),
             projects_physical_objects_data.c.properties.label("physical_object_properties"),
             projects_physical_objects_data.c.created_at.label("physical_object_created_at"),
@@ -50,6 +53,7 @@ async def get_scenario_urban_object_by_id_from_db(
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.territory_type_id,
             territory_types_dict.c.name.label("territory_type_name"),
         )
@@ -67,6 +71,11 @@ async def get_scenario_urban_object_by_id_from_db(
                 physical_object_types_dict,
                 physical_object_types_dict.c.physical_object_type_id
                 == projects_physical_objects_data.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
             .outerjoin(
                 projects_services_data, projects_services_data.c.service_id == projects_urban_objects_data.c.service_id

--- a/idu_api/urban_api/logic/impl/helpers/service_types.py
+++ b/idu_api/urban_api/logic/impl/helpers/service_types.py
@@ -72,6 +72,7 @@ async def add_service_type_to_db(
             capacity_modeled=service_type.capacity_modeled,
             code=service_type.code,
             infrastructure_type=service_type.infrastructure_type,
+            properties=service_type.properties,
         )
         .returning(service_types_dict.c.service_type_id)
     )
@@ -129,6 +130,7 @@ async def put_service_type_to_db(
             capacity_modeled=service_type.capacity_modeled,
             code=service_type.code,
             infrastructure_type=service_type.infrastructure_type,
+            properties=service_type.properties,
         )
     )
     await conn.execute(statement)
@@ -271,7 +273,7 @@ async def get_urban_functions_by_parent_id_from_db(
 
     result = (await conn.execute(statement)).mappings().all()
 
-    return [UrbanFunctionDTO(**indicator) for indicator in result]
+    return [UrbanFunctionDTO(**urban_function) for urban_function in result]
 
 
 async def add_urban_function_to_db(
@@ -505,5 +507,4 @@ async def get_service_types_hierarchy_from_db(
 
         return children
 
-    hierarchy = build_filtered_hierarchy()
-    return hierarchy
+    return build_filtered_hierarchy()

--- a/idu_api/urban_api/logic/impl/helpers/services.py
+++ b/idu_api/urban_api/logic/impl/helpers/services.py
@@ -35,6 +35,7 @@ async def get_service_by_id_from_db(conn: AsyncConnection, service_id: int) -> S
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.name.label("territory_type_name"),
         )
         .select_from(
@@ -236,6 +237,7 @@ async def get_service_with_territories_by_id_from_db(
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.name.label("territory_type_name"),
         )
         .select_from(

--- a/idu_api/urban_api/logic/impl/helpers/territories_buildings.py
+++ b/idu_api/urban_api/logic/impl/helpers/territories_buildings.py
@@ -69,7 +69,7 @@ async def get_living_buildings_with_geometry_by_territory_id_from_db(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,

--- a/idu_api/urban_api/logic/impl/helpers/territories_buildings.py
+++ b/idu_api/urban_api/logic/impl/helpers/territories_buildings.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from idu_api.common.db.entities import (
     living_buildings_data,
     object_geometries_data,
+    physical_object_functions_dict,
     physical_object_types_dict,
     physical_objects_data,
     territories_data,
@@ -52,6 +53,8 @@ async def get_living_buildings_with_geometry_by_territory_id_from_db(
             physical_objects_data.c.updated_at.label("physical_object_updated_at"),
             physical_object_types_dict.c.physical_object_type_id,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
             object_geometries_data.c.address.label("physical_object_address"),
             object_geometries_data.c.osm_id.label("object_geometry_osm_id"),
             cast(ST_AsGeoJSON(object_geometries_data.c.geometry), JSONB).label("geometry"),
@@ -65,6 +68,11 @@ async def get_living_buildings_with_geometry_by_territory_id_from_db(
             .join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
             .join(
                 urban_objects_data,

--- a/idu_api/urban_api/logic/impl/helpers/territories_physical_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/territories_physical_objects.py
@@ -66,7 +66,7 @@ async def get_physical_objects_by_territory_id_from_db(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,
@@ -148,7 +148,7 @@ async def get_physical_objects_with_geometry_by_territory_id_from_db(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,

--- a/idu_api/urban_api/logic/impl/helpers/territories_physical_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/territories_physical_objects.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 from idu_api.common.db.entities import (
     object_geometries_data,
+    physical_object_functions_dict,
     physical_object_types_dict,
     physical_objects_data,
     territories_data,
@@ -49,6 +50,8 @@ async def get_physical_objects_by_territory_id_from_db(
         select(
             physical_objects_data,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
         )
         .select_from(
             physical_objects_data.join(
@@ -62,6 +65,11 @@ async def get_physical_objects_by_territory_id_from_db(
             .join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
         )
         .where(object_geometries_data.c.territory_id.in_(select(territories_cte)))
@@ -120,6 +128,8 @@ async def get_physical_objects_with_geometry_by_territory_id_from_db(
         select(
             physical_objects_data,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
             object_geometries_data.c.address,
             object_geometries_data.c.osm_id,
             cast(ST_AsGeoJSON(object_geometries_data.c.geometry), JSONB).label("geometry"),
@@ -137,6 +147,11 @@ async def get_physical_objects_with_geometry_by_territory_id_from_db(
             .join(
                 physical_object_types_dict,
                 physical_objects_data.c.physical_object_type_id == physical_object_types_dict.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
         )
         .where(object_geometries_data.c.territory_id.in_(select(territories_cte)))

--- a/idu_api/urban_api/logic/impl/helpers/territory_services.py
+++ b/idu_api/urban_api/logic/impl/helpers/territory_services.py
@@ -106,6 +106,7 @@ async def get_services_by_territory_id_from_db(
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.name.label("territory_type_name"),
         )
         .select_from(
@@ -183,6 +184,7 @@ async def get_services_with_geometry_by_territory_id_from_db(
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.name.label("territory_type_name"),
             object_geometries_data.c.address,
             object_geometries_data.c.osm_id,

--- a/idu_api/urban_api/logic/impl/helpers/urban_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/urban_objects.py
@@ -70,7 +70,7 @@ async def get_urban_object_by_id_from_db(conn: AsyncConnection, urban_object_id:
                 physical_object_types_dict,
                 physical_object_types_dict.c.physical_object_type_id == physical_objects_data.c.physical_object_type_id,
             )
-            .join(
+            .outerjoin(
                 physical_object_functions_dict,
                 physical_object_functions_dict.c.physical_object_function_id
                 == physical_object_types_dict.c.physical_object_function_id,

--- a/idu_api/urban_api/logic/impl/helpers/urban_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/urban_objects.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 from idu_api.common.db.entities import (
     object_geometries_data,
+    physical_object_functions_dict,
     physical_object_types_dict,
     physical_objects_data,
     service_types_dict,
@@ -27,6 +28,8 @@ async def get_urban_object_by_id_from_db(conn: AsyncConnection, urban_object_id:
             urban_objects_data,
             physical_objects_data.c.physical_object_type_id,
             physical_object_types_dict.c.name.label("physical_object_type_name"),
+            physical_object_types_dict.c.physical_object_function_id,
+            physical_object_functions_dict.c.name.label("physical_object_function_name"),
             physical_objects_data.c.name.label("physical_object_name"),
             physical_objects_data.c.properties.label("physical_object_properties"),
             physical_objects_data.c.created_at.label("physical_object_created_at"),
@@ -50,6 +53,7 @@ async def get_urban_object_by_id_from_db(conn: AsyncConnection, urban_object_id:
             service_types_dict.c.capacity_modeled.label("service_type_capacity_modeled"),
             service_types_dict.c.code.label("service_type_code"),
             service_types_dict.c.infrastructure_type,
+            service_types_dict.c.properties.label("service_type_properties"),
             territory_types_dict.c.territory_type_id,
             territory_types_dict.c.name.label("territory_type_name"),
         )
@@ -65,6 +69,11 @@ async def get_urban_object_by_id_from_db(conn: AsyncConnection, urban_object_id:
             .join(
                 physical_object_types_dict,
                 physical_object_types_dict.c.physical_object_type_id == physical_objects_data.c.physical_object_type_id,
+            )
+            .join(
+                physical_object_functions_dict,
+                physical_object_functions_dict.c.physical_object_function_id
+                == physical_object_types_dict.c.physical_object_function_id,
             )
             .outerjoin(services_data, services_data.c.service_id == urban_objects_data.c.service_id)
             .outerjoin(service_types_dict, service_types_dict.c.service_type_id == services_data.c.service_type_id)

--- a/idu_api/urban_api/logic/impl/physical_object_types.py
+++ b/idu_api/urban_api/logic/impl/physical_object_types.py
@@ -1,0 +1,88 @@
+"""Physical object types handlers logic is defined here."""
+
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from idu_api.urban_api.dto import (
+    PhysicalObjectFunctionDTO,
+    PhysicalObjectTypeDTO,
+    PhysicalObjectTypesHierarchyDTO,
+)
+from idu_api.urban_api.logic.impl.helpers.physical_object_types import (
+    add_physical_object_function_to_db,
+    add_physical_object_type_to_db,
+    delete_physical_object_function_from_db,
+    delete_physical_object_type_from_db,
+    get_physical_object_functions_by_parent_id_from_db,
+    get_physical_object_types_from_db,
+    get_physical_object_types_hierarchy_from_db,
+    patch_physical_object_function_to_db,
+    patch_physical_object_type_to_db,
+    put_physical_object_function_to_db,
+)
+from idu_api.urban_api.logic.physical_object_types import PhysicalObjectTypesService
+from idu_api.urban_api.schemas import (
+    PhysicalObjectFunctionPatch,
+    PhysicalObjectFunctionPost,
+    PhysicalObjectFunctionPut,
+    PhysicalObjectsTypesPatch,
+    PhysicalObjectsTypesPost,
+)
+
+
+class PhysicalObjectTypesServiceImpl(PhysicalObjectTypesService):
+    """Service to manipulate physical objects entities.
+
+    Based on async SQLAlchemy connection.
+    """
+
+    def __init__(self, conn: AsyncConnection):
+        self._conn = conn
+
+    async def get_physical_object_types(self) -> list[PhysicalObjectTypeDTO]:
+        return await get_physical_object_types_from_db(self._conn)
+
+    async def add_physical_object_type(self, physical_object_type: PhysicalObjectsTypesPost) -> PhysicalObjectTypeDTO:
+        return await add_physical_object_type_to_db(self._conn, physical_object_type)
+
+    async def patch_physical_object_type(
+        self, physical_object_type_id: int, physical_object_type: PhysicalObjectsTypesPatch
+    ) -> PhysicalObjectTypeDTO:
+        return await patch_physical_object_type_to_db(self._conn, physical_object_type_id, physical_object_type)
+
+    async def delete_physical_object_type(self, physical_object_type_id: int) -> dict:
+        return await delete_physical_object_type_from_db(self._conn, physical_object_type_id)
+
+    async def get_physical_object_functions_by_parent_id(
+        self,
+        parent_id: int | None,
+        name: str | None,
+        get_all_subtree: bool,
+    ) -> list[PhysicalObjectFunctionDTO]:
+        return await get_physical_object_functions_by_parent_id_from_db(self._conn, parent_id, name, get_all_subtree)
+
+    async def add_physical_object_function(
+        self, physical_object_function: PhysicalObjectFunctionPost
+    ) -> PhysicalObjectFunctionDTO:
+        return await add_physical_object_function_to_db(self._conn, physical_object_function)
+
+    async def put_physical_object_function(
+        self, physical_object_function_id: int, physical_object_function: PhysicalObjectFunctionPut
+    ) -> PhysicalObjectFunctionDTO:
+        return await put_physical_object_function_to_db(
+            self._conn, physical_object_function_id, physical_object_function
+        )
+
+    async def patch_physical_object_function(
+        self, physical_object_function_id: int, physical_object_function: PhysicalObjectFunctionPatch
+    ) -> PhysicalObjectFunctionDTO:
+        return await patch_physical_object_function_to_db(
+            self._conn, physical_object_function_id, physical_object_function
+        )
+
+    async def delete_physical_object_function(self, physical_object_function_id: int) -> dict:
+        return await delete_physical_object_function_from_db(self._conn, physical_object_function_id)
+
+    async def get_physical_object_types_hierarchy(
+        self, physical_object_type_ids: str | None
+    ) -> list[PhysicalObjectTypesHierarchyDTO]:
+        return await get_physical_object_types_hierarchy_from_db(self._conn, physical_object_type_ids)

--- a/idu_api/urban_api/logic/impl/physical_objects.py
+++ b/idu_api/urban_api/logic/impl/physical_objects.py
@@ -7,7 +7,6 @@ from idu_api.urban_api.dto import (
     LivingBuildingsDTO,
     ObjectGeometryDTO,
     PhysicalObjectDataDTO,
-    PhysicalObjectTypeDTO,
     PhysicalObjectWithGeometryDTO,
     PhysicalObjectWithTerritoryDTO,
     ServiceDTO,
@@ -17,13 +16,11 @@ from idu_api.urban_api.dto import (
 from idu_api.urban_api.logic.impl.helpers.physical_objects import (
     add_living_building_to_db,
     add_physical_object_to_object_geometry_in_db,
-    add_physical_object_type_to_db,
     add_physical_object_with_geometry_to_db,
     delete_living_building_in_db,
     delete_physical_object_in_db,
     get_living_buildings_by_physical_object_id_from_db,
     get_physical_object_geometries_from_db,
-    get_physical_object_types_from_db,
     get_physical_object_with_territories_by_id_from_db,
     get_physical_objects_around_from_db,
     get_physical_objects_by_ids_from_db,
@@ -42,7 +39,6 @@ from idu_api.urban_api.schemas import (
     PhysicalObjectsDataPatch,
     PhysicalObjectsDataPost,
     PhysicalObjectsDataPut,
-    PhysicalObjectsTypesPost,
     PhysicalObjectWithGeometryPost,
 )
 
@@ -65,12 +61,6 @@ class PhysicalObjectsServiceImpl(PhysicalObjectsService):
         self, geometry: Geom, physical_object_type_id: int | None, buffer_meters: int
     ) -> list[PhysicalObjectWithGeometryDTO]:
         return await get_physical_objects_around_from_db(self._conn, geometry, physical_object_type_id, buffer_meters)
-
-    async def get_physical_object_types(self) -> list[PhysicalObjectTypeDTO]:
-        return await get_physical_object_types_from_db(self._conn)
-
-    async def add_physical_object_type(self, physical_object_type: PhysicalObjectsTypesPost) -> PhysicalObjectTypeDTO:
-        return await add_physical_object_type_to_db(self._conn, physical_object_type)
 
     async def add_physical_object_with_geometry(
         self, physical_object: PhysicalObjectWithGeometryPost

--- a/idu_api/urban_api/logic/physical_object_types.py
+++ b/idu_api/urban_api/logic/physical_object_types.py
@@ -1,0 +1,80 @@
+"""Physical object types handlers logic of getting entities from the database is defined here."""
+
+import abc
+from typing import Protocol
+
+from idu_api.urban_api.dto import (
+    PhysicalObjectFunctionDTO,
+    PhysicalObjectTypeDTO,
+    PhysicalObjectTypesHierarchyDTO,
+)
+from idu_api.urban_api.schemas import (
+    PhysicalObjectFunctionPatch,
+    PhysicalObjectFunctionPost,
+    PhysicalObjectFunctionPut,
+    PhysicalObjectsTypesPatch,
+    PhysicalObjectsTypesPost,
+)
+
+
+class PhysicalObjectTypesService(Protocol):
+    """physical object to manipulate physical object types."""
+
+    @abc.abstractmethod
+    async def get_physical_object_types(self) -> list[PhysicalObjectTypeDTO]:
+        """Get all physical object type objects."""
+
+    @abc.abstractmethod
+    async def add_physical_object_type(self, physical_object_type: PhysicalObjectsTypesPost) -> PhysicalObjectTypeDTO:
+        """Create physical object type object."""
+
+    @abc.abstractmethod
+    async def patch_physical_object_type(
+        self, physical_object_type_id: int, physical_object_type: PhysicalObjectsTypesPatch
+    ) -> PhysicalObjectTypeDTO:
+        """Update physical object type object by getting only given attributes."""
+
+    @abc.abstractmethod
+    async def delete_physical_object_type(self, physical_object_type_id: int) -> dict:
+        """Delete physical object type object by id."""
+
+    @abc.abstractmethod
+    async def get_physical_object_functions_by_parent_id(
+        self,
+        parent_id: int | None,
+        name: str | None,
+        get_all_subtree: bool,
+    ) -> list[PhysicalObjectFunctionDTO]:
+        """Get a physical object function or list of physical object functions by parent."""
+
+    @abc.abstractmethod
+    async def add_physical_object_function(
+        self, physical_object_function: PhysicalObjectFunctionPost
+    ) -> PhysicalObjectFunctionDTO:
+        """Create physical object function object."""
+
+    @abc.abstractmethod
+    async def put_physical_object_function(
+        self, physical_object_function_id: int, physical_object_function: PhysicalObjectFunctionPut
+    ) -> PhysicalObjectFunctionDTO:
+        """Update physical object function object by getting all its attributes."""
+
+    @abc.abstractmethod
+    async def patch_physical_object_function(
+        self, physical_object_function_id: int, physical_object_function: PhysicalObjectFunctionPatch
+    ) -> PhysicalObjectFunctionDTO:
+        """Update physical object function object by getting only given attributes."""
+
+    @abc.abstractmethod
+    async def delete_physical_object_function(self, physical_object_function_id: int) -> dict:
+        """Delete physical object function object by id."""
+
+    @abc.abstractmethod
+    async def get_physical_object_types_hierarchy(
+        self, physical_object_type_ids: str | None
+    ) -> list[PhysicalObjectTypesHierarchyDTO]:
+        """Get physical object types hierarchy (from top-level physical object function to physical object type)
+        based on a list of required physical object type ids.
+
+        If the list of identifiers was not passed, it returns the full hierarchy.
+        """

--- a/idu_api/urban_api/logic/physical_objects.py
+++ b/idu_api/urban_api/logic/physical_objects.py
@@ -9,7 +9,6 @@ from idu_api.urban_api.dto import (
     LivingBuildingsDTO,
     ObjectGeometryDTO,
     PhysicalObjectDataDTO,
-    PhysicalObjectTypeDTO,
     PhysicalObjectWithGeometryDTO,
     PhysicalObjectWithTerritoryDTO,
     ServiceDTO,
@@ -23,7 +22,6 @@ from idu_api.urban_api.schemas import (
     PhysicalObjectsDataPatch,
     PhysicalObjectsDataPost,
     PhysicalObjectsDataPut,
-    PhysicalObjectsTypesPost,
     PhysicalObjectWithGeometryPost,
 )
 
@@ -42,14 +40,6 @@ class PhysicalObjectsService(Protocol):
         self, geometry: Geom, physical_object_type_id: int | None, buffer_meters: int
     ) -> list[PhysicalObjectWithGeometryDTO]:
         """Get physical objects which are in buffer area of the given geometry."""
-
-    @abc.abstractmethod
-    async def get_physical_object_types(self) -> list[PhysicalObjectTypeDTO]:
-        """Get all physical object type objects."""
-
-    @abc.abstractmethod
-    async def add_physical_object_type(self, physical_object_type: PhysicalObjectsTypesPost) -> PhysicalObjectTypeDTO:
-        """Create physical object type object."""
 
     @abc.abstractmethod
     async def add_physical_object_with_geometry(

--- a/idu_api/urban_api/logic/service_types.py
+++ b/idu_api/urban_api/logic/service_types.py
@@ -26,15 +26,15 @@ class ServiceTypesService(Protocol):
         """Create service type object."""
 
     @abc.abstractmethod
-    async def put_service_type(self, service_type_id: int, service_type: ServiceTypesPut):
+    async def put_service_type(self, service_type_id: int, service_type: ServiceTypesPut) -> ServiceTypesDTO:
         """Update service type object by getting all its attributes."""
 
     @abc.abstractmethod
-    async def patch_service_type(self, service_type_id: int, service_type: ServiceTypesPatch):
+    async def patch_service_type(self, service_type_id: int, service_type: ServiceTypesPatch) -> ServiceTypesDTO:
         """Update service type object by getting only given attributes."""
 
     @abc.abstractmethod
-    async def delete_service_type(self, service_type_id: int):
+    async def delete_service_type(self, service_type_id: int) -> dict:
         """Delete service type object by id."""
 
     @abc.abstractmethod
@@ -51,15 +51,17 @@ class ServiceTypesService(Protocol):
         """Create urban function object."""
 
     @abc.abstractmethod
-    async def put_urban_function(self, urban_function_id: int, urban_function: UrbanFunctionPut):
+    async def put_urban_function(self, urban_function_id: int, urban_function: UrbanFunctionPut) -> UrbanFunctionDTO:
         """Update urban function object by getting all its attributes."""
 
     @abc.abstractmethod
-    async def patch_urban_function(self, urban_function_id: int, urban_function: UrbanFunctionPatch):
+    async def patch_urban_function(
+        self, urban_function_id: int, urban_function: UrbanFunctionPatch
+    ) -> UrbanFunctionDTO:
         """Update urban function object by getting only given attributes."""
 
     @abc.abstractmethod
-    async def delete_urban_function(self, urban_function_id: int):
+    async def delete_urban_function(self, urban_function_id: int) -> dict:
         """Delete urban function object by id."""
 
     @abc.abstractmethod

--- a/idu_api/urban_api/middlewares/dependency_injection.py
+++ b/idu_api/urban_api/middlewares/dependency_injection.py
@@ -1,4 +1,4 @@
-"""Dependency indejction middleware is defined here."""
+"""Dependency injection middleware is defined here."""
 
 from asyncio import Lock
 from typing import Any, Callable

--- a/idu_api/urban_api/schemas/__init__.py
+++ b/idu_api/urban_api/schemas/__init__.py
@@ -26,13 +26,21 @@ from .living_buildings import (
 from .normatives import Normative, NormativeDelete, NormativePatch, NormativePost
 from .object_geometries import ObjectGeometries, ObjectGeometriesPatch, ObjectGeometriesPost, ObjectGeometriesPut
 from .pages import Page
+from .physical_object_types import (
+    PhysicalObjectFunction,
+    PhysicalObjectFunctionPatch,
+    PhysicalObjectFunctionPost,
+    PhysicalObjectFunctionPut,
+    PhysicalObjectsTypes,
+    PhysicalObjectsTypesHierarchy,
+    PhysicalObjectsTypesPatch,
+    PhysicalObjectsTypesPost,
+)
 from .physical_objects import (
     PhysicalObjectsData,
     PhysicalObjectsDataPatch,
     PhysicalObjectsDataPost,
     PhysicalObjectsDataPut,
-    PhysicalObjectsTypes,
-    PhysicalObjectsTypesPost,
     PhysicalObjectsWithTerritory,
     PhysicalObjectWithGeometry,
     PhysicalObjectWithGeometryPost,
@@ -146,7 +154,13 @@ __all__ = [
     "PhysicalObjectsWithTerritory",
     "PhysicalObjectsDataPut",
     "PhysicalObjectWithGeometry",
+    "PhysicalObjectFunction",
+    "PhysicalObjectFunctionPatch",
+    "PhysicalObjectFunctionPost",
+    "PhysicalObjectFunctionPut",
     "PhysicalObjectsTypes",
+    "PhysicalObjectsTypesHierarchy",
+    "PhysicalObjectsTypesPatch",
     "PhysicalObjectsTypesPost",
     "LivingBuildingsData",
     "LivingBuildingsDataPatch",

--- a/idu_api/urban_api/schemas/living_buildings.py
+++ b/idu_api/urban_api/schemas/living_buildings.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from idu_api.urban_api.dto import LivingBuildingsDTO, LivingBuildingsWithGeometryDTO
 from idu_api.urban_api.schemas.geometries import Geometry
+from idu_api.urban_api.schemas.physical_object_types import PhysicalObjectFunctionBasic
 from idu_api.urban_api.schemas.physical_objects import PhysicalObjectsData, PhysicalObjectsTypes
 
 
@@ -32,7 +33,11 @@ class LivingBuildingsWithGeometry(BaseModel):
             physical_object=PhysicalObjectsData(
                 physical_object_id=dto.physical_object_id,
                 physical_object_type=PhysicalObjectsTypes(
-                    physical_object_type_id=dto.physical_object_type_id, name=dto.physical_object_type_name
+                    physical_object_type_id=dto.physical_object_type_id,
+                    name=dto.physical_object_type_name,
+                    physical_object_function=PhysicalObjectFunctionBasic(
+                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    ),
                 ),
                 name=dto.physical_object_name,
                 properties=dto.physical_object_properties,
@@ -70,7 +75,11 @@ class LivingBuildingsData(BaseModel):
             physical_object=PhysicalObjectsData(
                 physical_object_id=dto.physical_object_id,
                 physical_object_type=PhysicalObjectsTypes(
-                    physical_object_type_id=dto.physical_object_type_id, name=dto.physical_object_type_name
+                    physical_object_type_id=dto.physical_object_type_id,
+                    name=dto.physical_object_type_name,
+                    physical_object_function=PhysicalObjectFunctionBasic(
+                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    ),
                 ),
                 name=dto.physical_object_name,
                 created_at=dto.physical_object_created_at,

--- a/idu_api/urban_api/schemas/living_buildings.py
+++ b/idu_api/urban_api/schemas/living_buildings.py
@@ -77,8 +77,12 @@ class LivingBuildingsData(BaseModel):
                 physical_object_type=PhysicalObjectsTypes(
                     physical_object_type_id=dto.physical_object_type_id,
                     name=dto.physical_object_type_name,
-                    physical_object_function=PhysicalObjectFunctionBasic(
-                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    physical_object_function=(
+                        PhysicalObjectFunctionBasic(
+                            id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                        )
+                        if dto.physical_object_function_id is not None
+                        else None
                     ),
                 ),
                 name=dto.physical_object_name,

--- a/idu_api/urban_api/schemas/physical_object_types.py
+++ b/idu_api/urban_api/schemas/physical_object_types.py
@@ -30,7 +30,7 @@ class PhysicalObjectsTypes(BaseModel):
 
     physical_object_type_id: int = Field(..., description="physical object type identifier", examples=[1])
     name: str = Field(..., description="physical object type unit name", examples=["Здание"])
-    physical_object_function: PhysicalObjectFunctionBasic
+    physical_object_function: PhysicalObjectFunctionBasic | None
 
     @classmethod
     def from_dto(cls, dto: PhysicalObjectTypeDTO) -> "PhysicalObjectsTypes":
@@ -40,9 +40,13 @@ class PhysicalObjectsTypes(BaseModel):
         return cls(
             physical_object_type_id=dto.physical_object_type_id,
             name=dto.name,
-            physical_object_function=PhysicalObjectFunctionBasic(
-                id=dto.physical_object_function_id,
-                name=dto.physical_object_function_name,
+            physical_object_function=(
+                PhysicalObjectFunctionBasic(
+                    id=dto.physical_object_function_id,
+                    name=dto.physical_object_function_name,
+                )
+                if dto.physical_object_function_id is not None
+                else None
             ),
         )
 

--- a/idu_api/urban_api/schemas/physical_object_types.py
+++ b/idu_api/urban_api/schemas/physical_object_types.py
@@ -1,0 +1,156 @@
+"""Physical object type schemas are defined here."""
+
+from typing import Self
+
+from pydantic import BaseModel, Field, model_validator
+
+from idu_api.urban_api.dto import (
+    PhysicalObjectFunctionDTO,
+    PhysicalObjectTypeDTO,
+    PhysicalObjectTypesHierarchyDTO,
+)
+
+
+class PhysicalObjectTypeBasic(BaseModel):
+    """Basic physical object type model to encapsulate in other models."""
+
+    id: int
+    name: str
+
+
+class PhysicalObjectFunctionBasic(BaseModel):
+    """Basic physical object function model to encapsulate in other models."""
+
+    id: int
+    name: str
+
+
+class PhysicalObjectsTypes(BaseModel):
+    """Physical object type with all its attributes."""
+
+    physical_object_type_id: int = Field(..., description="physical object type identifier", examples=[1])
+    name: str = Field(..., description="physical object type unit name", examples=["Здание"])
+    physical_object_function: PhysicalObjectFunctionBasic
+
+    @classmethod
+    def from_dto(cls, dto: PhysicalObjectTypeDTO) -> "PhysicalObjectsTypes":
+        """
+        Construct from DTO.
+        """
+        return cls(
+            physical_object_type_id=dto.physical_object_type_id,
+            name=dto.name,
+            physical_object_function=PhysicalObjectFunctionBasic(
+                id=dto.physical_object_function_id,
+                name=dto.physical_object_function_name,
+            ),
+        )
+
+
+class PhysicalObjectsTypesPost(BaseModel):
+    """Schema of physical object type for POST request."""
+
+    name: str = Field(..., description="physical object type unit name", examples=["Здание"])
+    physical_object_function_id: int = Field(..., description="function identifier", examples=[1])
+
+
+class PhysicalObjectsTypesPatch(BaseModel):
+    """Schema of physical object type for PATCH request."""
+
+    name: str | None = Field(None, description="physical object type unit name", examples=["Здание"])
+    physical_object_function_id: int | None = Field(None, description="function identifier", examples=[1])
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_empty_request(cls, values):
+        """Ensure the request body is not empty."""
+        if not values:
+            raise ValueError("request body cannot be empty")
+        return values
+
+
+class PhysicalObjectFunction(BaseModel):
+    """Physical object function with all its attributes."""
+
+    physical_object_function_id: int = Field(..., examples=[1])
+    parent_physical_object_function: PhysicalObjectFunctionBasic | None
+    name: str = Field(..., description="physical object function unit name", examples=["--"])
+    level: int = Field(..., description="number of urban functions above in a tree + [1]", examples=[1])
+    list_label: str = Field(..., description="physical object function list label", examples=["1.1.1"])
+    code: str = Field(..., description="physical object function code", examples=["1"])
+
+    @classmethod
+    def from_dto(cls, dto: PhysicalObjectFunctionDTO) -> "PhysicalObjectFunction":
+        """
+        Construct from DTO.
+        """
+        return cls(
+            physical_object_function_id=dto.physical_object_function_id,
+            parent_physical_object_function=(
+                PhysicalObjectFunctionBasic(id=dto.parent_id, name=dto.parent_name)
+                if dto.parent_id is not None
+                else None
+            ),
+            name=dto.name,
+            level=dto.level,
+            list_label=dto.list_label,
+            code=dto.code,
+        )
+
+
+class PhysicalObjectFunctionPost(BaseModel):
+    """Schema of physical object function for POST request."""
+
+    name: str = Field(..., description="physical object function unit name", examples=["--"])
+    parent_id: int | None = Field(None, description="physical object function parent id, if set", examples=[1])
+    code: str = Field(..., description="physical object function code", examples=["1"])
+
+
+class PhysicalObjectFunctionPut(BaseModel):
+    """Schema of physical object function for PUT request."""
+
+    name: str = Field(..., description="physical object function unit name", examples=["--"])
+    parent_id: int | None = Field(..., description="physical object function parent id, if set", examples=[1])
+    code: str = Field(..., description="physical object function code", examples=["1"])
+
+
+class PhysicalObjectFunctionPatch(BaseModel):
+    """Schema of physical object function for PATCH request."""
+
+    name: str | None = Field(..., description="physical object function unit name", examples=["--"])
+    parent_id: int | None = Field(None, description="physical object function parent id, if set", examples=[1])
+    code: str | None = Field(..., description="physical object function code", examples=["1"])
+
+
+class PhysicalObjectsTypesHierarchy(BaseModel):
+    physical_object_function_id: int = Field(..., examples=[1])
+    parent_id: int | None = Field(
+        ..., description="Parent urban function identifier (null if it is top-level urban function", examples=[1]
+    )
+    name: str = Field(..., description="Urban function unit name", examples=["--"])
+    level: int = Field(..., description="Number of urban functions above in a tree + [1]", examples=[1])
+    list_label: str = Field(..., description="Urban function list label", examples=["1.1.1"])
+    code: str = Field(..., description="Urban function code", examples=["1"])
+    children: list[Self | PhysicalObjectsTypes]
+
+    @classmethod
+    def from_dto(cls, dto: PhysicalObjectTypesHierarchyDTO) -> "PhysicalObjectsTypesHierarchy":
+        """
+        Construct from DTO.
+        """
+        return cls(
+            physical_object_function_id=dto.physical_object_function_id,
+            parent_id=dto.parent_id,
+            name=dto.name,
+            level=dto.level,
+            list_label=dto.list_label,
+            code=dto.code,
+            children=[
+                (
+                    PhysicalObjectsTypesHierarchy.from_dto(child)
+                    if isinstance(child, PhysicalObjectTypesHierarchyDTO)
+                    else PhysicalObjectsTypes.from_dto(child)
+                )
+                for child in dto.children
+            ],
+        )

--- a/idu_api/urban_api/schemas/physical_objects.py
+++ b/idu_api/urban_api/schemas/physical_objects.py
@@ -47,8 +47,12 @@ class PhysicalObjectsData(BaseModel):
             physical_object_type=PhysicalObjectsTypes(
                 physical_object_type_id=dto.physical_object_type_id,
                 name=dto.physical_object_type_name,
-                physical_object_function=PhysicalObjectFunctionBasic(
-                    id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                physical_object_function=(
+                    PhysicalObjectFunctionBasic(
+                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    )
+                    if dto.physical_object_function_id is not None
+                    else None
                 ),
             ),
             name=dto.name,
@@ -85,8 +89,12 @@ class PhysicalObjectsWithTerritory(BaseModel):
             physical_object_type=PhysicalObjectsTypes(
                 physical_object_type_id=dto.physical_object_type_id,
                 name=dto.physical_object_type_name,
-                physical_object_function=PhysicalObjectFunctionBasic(
-                    id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                physical_object_function=(
+                    PhysicalObjectFunctionBasic(
+                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    )
+                    if dto.physical_object_function_id is not None
+                    else None
                 ),
             ),
             name=dto.name,
@@ -128,8 +136,12 @@ class PhysicalObjectWithGeometry(BaseModel):
             physical_object_type=PhysicalObjectsTypes(
                 physical_object_type_id=dto.physical_object_type_id,
                 name=dto.physical_object_type_name,
-                physical_object_function=PhysicalObjectFunctionBasic(
-                    id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                physical_object_function=(
+                    PhysicalObjectFunctionBasic(
+                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    )
+                    if dto.physical_object_function_id is not None
+                    else None
                 ),
             ),
             name=dto.name,

--- a/idu_api/urban_api/schemas/physical_objects.py
+++ b/idu_api/urban_api/schemas/physical_objects.py
@@ -1,3 +1,5 @@
+"""Physical object schemas are defined here."""
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
@@ -6,11 +8,11 @@ from pydantic import BaseModel, Field, model_validator
 
 from idu_api.urban_api.dto import (
     PhysicalObjectDataDTO,
-    PhysicalObjectTypeDTO,
     PhysicalObjectWithGeometryDTO,
     PhysicalObjectWithTerritoryDTO,
 )
 from idu_api.urban_api.schemas.geometries import Geometry, GeometryValidationModel
+from idu_api.urban_api.schemas.physical_object_types import PhysicalObjectFunctionBasic, PhysicalObjectsTypes
 from idu_api.urban_api.schemas.territories import ShortTerritory
 
 
@@ -19,34 +21,8 @@ class PhysicalObjectsOrderByField(str, Enum):
     UPDATED_AT = "updated_at"
 
 
-class PhysicalObjectsTypes(BaseModel):
-    """
-    Physical object type with all its attributes
-    """
-
-    physical_object_type_id: int = Field(..., description="Physical object type id, if set", examples=[1])
-    name: str = Field(..., description="Physical object type unit name", examples=["Здание"])
-
-    @classmethod
-    def from_dto(cls, dto: PhysicalObjectTypeDTO) -> "PhysicalObjectsTypes":
-        """
-        Construct from DTO.
-        """
-        return cls(physical_object_type_id=dto.physical_object_type_id, name=dto.name)
-
-
-class PhysicalObjectsTypesPost(BaseModel):
-    """
-    Schema of physical object type for POST request
-    """
-
-    name: str = Field(..., description="Physical object type unit name", examples=["Здание"])
-
-
 class PhysicalObjectsData(BaseModel):
-    """
-    Physical object with all its attributes
-    """
+    """Physical object with all its attributes."""
 
     physical_object_id: int = Field(..., examples=[1])
     physical_object_type: PhysicalObjectsTypes
@@ -69,7 +45,11 @@ class PhysicalObjectsData(BaseModel):
         return cls(
             physical_object_id=dto.physical_object_id,
             physical_object_type=PhysicalObjectsTypes(
-                physical_object_type_id=dto.physical_object_type_id, name=dto.physical_object_type_name
+                physical_object_type_id=dto.physical_object_type_id,
+                name=dto.physical_object_type_name,
+                physical_object_function=PhysicalObjectFunctionBasic(
+                    id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                ),
             ),
             name=dto.name,
             properties=dto.properties,
@@ -79,9 +59,7 @@ class PhysicalObjectsData(BaseModel):
 
 
 class PhysicalObjectsWithTerritory(BaseModel):
-    """
-    Physical object with all its attributes and parent territory
-    """
+    """Physical object with all its attributes and parent territory."""
 
     physical_object_id: int = Field(..., examples=[1])
     physical_object_type: PhysicalObjectsTypes
@@ -105,7 +83,11 @@ class PhysicalObjectsWithTerritory(BaseModel):
         return cls(
             physical_object_id=dto.physical_object_id,
             physical_object_type=PhysicalObjectsTypes(
-                physical_object_type_id=dto.physical_object_type_id, name=dto.physical_object_type_name
+                physical_object_type_id=dto.physical_object_type_id,
+                name=dto.physical_object_type_name,
+                physical_object_function=PhysicalObjectFunctionBasic(
+                    id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                ),
             ),
             name=dto.name,
             properties=dto.properties,
@@ -144,7 +126,11 @@ class PhysicalObjectWithGeometry(BaseModel):
         return cls(
             physical_object_id=dto.physical_object_id,
             physical_object_type=PhysicalObjectsTypes(
-                physical_object_type_id=dto.physical_object_type_id, name=dto.physical_object_type_name
+                physical_object_type_id=dto.physical_object_type_id,
+                name=dto.physical_object_type_name,
+                physical_object_function=PhysicalObjectFunctionBasic(
+                    id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                ),
             ),
             name=dto.name,
             address=dto.address,
@@ -157,9 +143,7 @@ class PhysicalObjectWithGeometry(BaseModel):
 
 
 class PhysicalObjectWithGeometryPost(GeometryValidationModel):
-    """
-    Schema of physical object with geometry for POST request
-    """
+    """Schema of physical object with geometry for POST request."""
 
     territory_id: int = Field(..., examples=[1])
     geometry: Geometry
@@ -176,9 +160,7 @@ class PhysicalObjectWithGeometryPost(GeometryValidationModel):
 
 
 class PhysicalObjectsDataPost(BaseModel):
-    """
-    Schema of physical object for POST request
-    """
+    """Schema of physical object for POST request."""
 
     physical_object_type_id: int = Field(..., examples=[1])
     name: str | None = Field(None, description="Physical object name", examples=["--"])
@@ -190,9 +172,7 @@ class PhysicalObjectsDataPost(BaseModel):
 
 
 class PhysicalObjectsDataPut(BaseModel):
-    """
-    Schema of physical object for PUT request
-    """
+    """Schema of physical object for PUT request."""
 
     physical_object_type_id: int = Field(..., examples=[1])
     name: str | None = Field(..., description="Physical object name", examples=["--"])
@@ -204,9 +184,7 @@ class PhysicalObjectsDataPut(BaseModel):
 
 
 class PhysicalObjectsDataPatch(BaseModel):
-    """
-    Schema of physical object for PATCH request
-    """
+    """Schema of physical object for PATCH request."""
 
     physical_object_type_id: int | None = Field(None, examples=[1])
     name: str | None = Field(None, description="Physical object name", examples=["--"])

--- a/idu_api/urban_api/schemas/scenarios_urban_objects.py
+++ b/idu_api/urban_api/schemas/scenarios_urban_objects.py
@@ -29,8 +29,12 @@ class ScenariosUrbanObject(BaseModel):
                 physical_object_type=PhysicalObjectsTypes(
                     physical_object_type_id=dto.physical_object_type_id,
                     name=dto.physical_object_type_name,
-                    physical_object_function=PhysicalObjectFunctionBasic(
-                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    physical_object_function=(
+                        PhysicalObjectFunctionBasic(
+                            id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                        )
+                        if dto.physical_object_function_id is not None
+                        else None
                     ),
                 ),
                 name=dto.physical_object_name,

--- a/idu_api/urban_api/schemas/scenarios_urban_objects.py
+++ b/idu_api/urban_api/schemas/scenarios_urban_objects.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from idu_api.urban_api.dto import ScenarioUrbanObjectDTO
 from idu_api.urban_api.schemas.geometries import Geometry
 from idu_api.urban_api.schemas.object_geometries import ObjectGeometries
+from idu_api.urban_api.schemas.physical_object_types import PhysicalObjectFunctionBasic
 from idu_api.urban_api.schemas.physical_objects import PhysicalObjectsData, PhysicalObjectsTypes
 from idu_api.urban_api.schemas.service_types import ServiceTypes, UrbanFunctionBasic
 from idu_api.urban_api.schemas.services import ServicesData
@@ -26,7 +27,11 @@ class ScenariosUrbanObject(BaseModel):
             physical_object=PhysicalObjectsData(
                 physical_object_id=dto.physical_object_id,
                 physical_object_type=PhysicalObjectsTypes(
-                    physical_object_type_id=dto.physical_object_type_id, name=dto.physical_object_type_name
+                    physical_object_type_id=dto.physical_object_type_id,
+                    name=dto.physical_object_type_name,
+                    physical_object_function=PhysicalObjectFunctionBasic(
+                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    ),
                 ),
                 name=dto.physical_object_name,
                 properties=dto.physical_object_properties,
@@ -53,6 +58,7 @@ class ScenariosUrbanObject(BaseModel):
                         capacity_modeled=dto.service_type_capacity_modeled,
                         code=dto.service_type_code,
                         infrastructure_type=dto.infrastructure_type,
+                        properties=dto.service_type_properties,
                     ),
                     territory_type=(
                         TerritoryType(territory_type_id=dto.territory_type_id, name=dto.territory_type_name)

--- a/idu_api/urban_api/schemas/service_types.py
+++ b/idu_api/urban_api/schemas/service_types.py
@@ -31,6 +31,11 @@ class ServiceTypes(BaseModel):
     infrastructure_type: Literal["basic", "additional", "comfort"] = Field(
         ..., description="infrastructure type", examples=["basic"]
     )
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Service type additional properties",
+        examples=[{"additional_attribute_name": "additional_attribute_value"}],
+    )
 
     @field_validator("infrastructure_type", mode="before")
     @staticmethod
@@ -54,6 +59,7 @@ class ServiceTypes(BaseModel):
             capacity_modeled=dto.capacity_modeled,
             code=dto.code,
             infrastructure_type=dto.infrastructure_type,
+            properties=dto.properties,
         )
 
 
@@ -65,6 +71,11 @@ class ServiceTypesPost(BaseModel):
     infrastructure_type: Literal["basic", "additional", "comfort"] = Field(
         ..., description="infrastructure type", examples=["basic"]
     )
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Service type additional properties",
+        examples=[{"additional_attribute_name": "additional_attribute_value"}],
+    )
 
 
 class ServiceTypesPut(BaseModel):
@@ -75,6 +86,11 @@ class ServiceTypesPut(BaseModel):
     infrastructure_type: Literal["basic", "additional", "comfort"] = Field(
         ..., description="infrastructure type", examples=["basic"]
     )
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Service type additional properties",
+        examples=[{"additional_attribute_name": "additional_attribute_value"}],
+    )
 
 
 class ServiceTypesPatch(BaseModel):
@@ -84,6 +100,11 @@ class ServiceTypesPatch(BaseModel):
     code: str | None = Field(None, description="Service type code", examples=["1"])
     infrastructure_type: Literal["basic", "additional", "comfort"] | None = Field(
         None, description="infrastructure type", examples=["basic"]
+    )
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Service type additional properties",
+        examples=[{"additional_attribute_name": "additional_attribute_value"}],
     )
 
     @model_validator(mode="before")

--- a/idu_api/urban_api/schemas/services.py
+++ b/idu_api/urban_api/schemas/services.py
@@ -52,6 +52,7 @@ class ServicesData(BaseModel):
                 capacity_modeled=dto.service_type_capacity_modeled,
                 code=dto.service_type_code,
                 infrastructure_type=dto.infrastructure_type,
+                properties=dto.service_type_properties,
             ),
             territory_type=(
                 TerritoryType(territory_type_id=dto.territory_type_id, name=dto.territory_type_name)
@@ -100,6 +101,7 @@ class ServiceWithTerritories(BaseModel):
                 capacity_modeled=dto.service_type_capacity_modeled,
                 code=dto.service_type_code,
                 infrastructure_type=dto.infrastructure_type,
+                properties=dto.service_type_properties,
             ),
             territory_type=(
                 TerritoryType(territory_type_id=dto.territory_type_id, name=dto.territory_type_name)
@@ -201,6 +203,7 @@ class ServicesDataWithGeometry(BaseModel):
                 capacity_modeled=dto.service_type_capacity_modeled,
                 code=dto.service_type_code,
                 infrastructure_type=dto.infrastructure_type,
+                properties=dto.service_type_properties,
             ),
             territory_type=(
                 TerritoryType(territory_type_id=dto.territory_type_id, name=dto.territory_type_name)

--- a/idu_api/urban_api/schemas/territories.py
+++ b/idu_api/urban_api/schemas/territories.py
@@ -1,6 +1,4 @@
-"""
-Territory schemas are defined here.
-"""
+"""Territory schemas are defined here."""
 
 from datetime import datetime
 from enum import Enum
@@ -57,21 +55,21 @@ class TerritoryData(BaseModel):
     territory_id: int = Field(..., examples=[1])
     territory_type: TerritoryType
     parent: TerritoryShortInfo | None
-    name: str = Field(..., description="Territory name", examples=["--"])
+    name: str = Field(..., description="territory name", examples=["--"])
     geometry: Geometry
     level: int = Field(..., examples=[1])
     properties: dict[str, Any] = Field(
         default_factory=dict,
-        description="Service additional properties",
+        description="territory additional properties",
         examples=[{"additional_attribute_name": "additional_attribute_value"}],
     )
     centre_point: Geometry
     admin_center: int | None = Field(..., examples=[1])
     okato_code: str | None = Field(..., examples=["1"])
     oktmo_code: str | None = Field(..., examples=["1"])
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="The time when the territory was created")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="the time when the territory was created")
     updated_at: datetime = Field(
-        default_factory=datetime.utcnow, description="The time when the territory was last updated"
+        default_factory=datetime.utcnow, description="the time when the territory was last updated"
     )
 
     @classmethod

--- a/idu_api/urban_api/schemas/urban_objects.py
+++ b/idu_api/urban_api/schemas/urban_objects.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from idu_api.urban_api.dto import UrbanObjectDTO
 from idu_api.urban_api.schemas.geometries import Geometry
 from idu_api.urban_api.schemas.object_geometries import ObjectGeometries
+from idu_api.urban_api.schemas.physical_object_types import PhysicalObjectFunctionBasic
 from idu_api.urban_api.schemas.physical_objects import PhysicalObjectsData, PhysicalObjectsTypes
 from idu_api.urban_api.schemas.service_types import ServiceTypes, UrbanFunctionBasic
 from idu_api.urban_api.schemas.services import ServicesData
@@ -24,7 +25,11 @@ class UrbanObject(BaseModel):
             physical_object=PhysicalObjectsData(
                 physical_object_id=dto.physical_object_id,
                 physical_object_type=PhysicalObjectsTypes(
-                    physical_object_type_id=dto.physical_object_type_id, name=dto.physical_object_type_name
+                    physical_object_type_id=dto.physical_object_type_id,
+                    name=dto.physical_object_type_name,
+                    physical_object_function=PhysicalObjectFunctionBasic(
+                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    ),
                 ),
                 name=dto.physical_object_name,
                 properties=dto.physical_object_properties,
@@ -51,6 +56,7 @@ class UrbanObject(BaseModel):
                         capacity_modeled=dto.service_type_capacity_modeled,
                         code=dto.service_type_code,
                         infrastructure_type=dto.infrastructure_type,
+                        properties=dto.service_type_properties,
                     ),
                     territory_type=(
                         TerritoryType(territory_type_id=dto.territory_type_id, name=dto.territory_type_name)

--- a/idu_api/urban_api/schemas/urban_objects.py
+++ b/idu_api/urban_api/schemas/urban_objects.py
@@ -27,8 +27,12 @@ class UrbanObject(BaseModel):
                 physical_object_type=PhysicalObjectsTypes(
                     physical_object_type_id=dto.physical_object_type_id,
                     name=dto.physical_object_type_name,
-                    physical_object_function=PhysicalObjectFunctionBasic(
-                        id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                    physical_object_function=(
+                        PhysicalObjectFunctionBasic(
+                            id=dto.physical_object_function_id, name=dto.physical_object_function_name
+                        )
+                        if dto.physical_object_function_id is not None
+                        else None
                     ),
                 ),
                 name=dto.physical_object_name,

--- a/idu_api/urban_api/version.py
+++ b/idu_api/urban_api/version.py
@@ -1,4 +1,4 @@
 """Version constants are defined here and should be updated on release."""
 
-VERSION = "0.21.0"
-LAST_UPDATE = "2024-10-21"
+VERSION = "0.21.1"
+LAST_UPDATE = "2024-10-22"

--- a/idu_api/urban_api/version.py
+++ b/idu_api/urban_api/version.py
@@ -1,4 +1,4 @@
 """Version constants are defined here and should be updated on release."""
 
-VERSION = "0.20.1"
-LAST_UPDATE = "2024-10-19"
+VERSION = "0.21.0"
+LAST_UPDATE = "2024-10-21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idu-api"
-version = "1.13.0"
+version = "1.13.1"
 description = "This is a Digital Territories Platform API in two versions to access and manipulate basic territories data."
 authors = ["Babayev Ruslan <rus.babaef@yandex.ru>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idu-api"
-version = "1.12.1"
+version = "1.13.0"
 description = "This is a Digital Territories Platform API in two versions to access and manipulate basic territories data."
 authors = ["Babayev Ruslan <rus.babaef@yandex.ru>"]
 readme = "README.md"


### PR DESCRIPTION
Changes:
- new migrations (create table `physical_object_functions_dict` with triggers, add column `physical_object_function_id` to `physical_object_types_dict`, add column `properties` to `service_types_dict`)
- add physical object types service/router
- add methods to get/post/put/patch/delete physical object functions, get full physical object types hierarchy
- fix logic/schemas with physical objects and services