### PR TITLE
Adding Github Actions deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           git co main;
           git pull;
           echo '--- DOCKER OPERATIONS ---';
-          docker compose down;
+          docker compose down -f "urban_api/docker-compose.yml";
           echo '--- LIST OF DOCKER CONTAINERS AFTER STOPPING DOCKER CONTAINERS ---';
           docker ps;
           docker compose up -f "urban_api/docker-compose.yml" -d --build;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: deploy
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  deploy-509:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run command on remote server
+      uses: D3rHase/ssh-command-action@v0.2.2
+      with:
+        host: ${{secrets.SSH_HOST_509}}
+        user: ${{secrets.SSH_USER_509}}
+        private_key: ${{secrets.SSH_PRIVATE_KEY_509}}
+        command: |
+          echo '--- START WORK ON REMOTE SERVER ---';
+          cd ${{ secrets.PROJECT_FOLDER_509 }};
+          echo '--- LIST OF FILES ---';
+          ls -al;
+          echo '--- GIT INFORMATION ---'
+          git co main;
+          git pull;
+          echo '--- DOCKER OPERATIONS ---';
+          docker compose down;
+          echo '--- LIST OF DOCKER CONTAINERS AFTER STOPPING DOCKER CONTAINERS ---';
+          docker ps;
+          docker compose up -d --build;
+          docker system prune --all --force;
+          echo '--- LIST OF DOCKER CONTAINERS AFTER STARTING DOCKER CONTAINERS ---';
+          docker ps;
+  deploy-107:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run command on remote server
+        uses: D3rHase/ssh-command-action@v0.2.2
+        with:
+          host: ${{secrets.SSH_HOST_107}}
+          user: ${{secrets.SSH_USER_107}}
+          private_key: ${{secrets.SSH_PRIVATE_KEY_107}}
+          command: |
+            echo '--- START WORK ON REMOTE SERVER ---';
+            cd ${{ secrets.PROJECT_FOLDER_107 }};
+            echo '--- LIST OF FILES ---';
+            ls -al;
+            echo '--- GIT INFORMATION ---'
+            git co main;
+            git pull;
+            echo '--- DOCKER OPERATIONS ---';
+            docker compose down;
+            echo '--- LIST OF DOCKER CONTAINERS AFTER STOPPING DOCKER CONTAINERS ---';
+            docker ps;
+            docker compose up -d --build;
+            docker system prune --all --force;
+            echo '--- LIST OF DOCKER CONTAINERS AFTER STARTING DOCKER CONTAINERS ---';
+            docker ps;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: deploy
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   deploy-509:
@@ -28,7 +26,7 @@ jobs:
           docker compose down;
           echo '--- LIST OF DOCKER CONTAINERS AFTER STOPPING DOCKER CONTAINERS ---';
           docker ps;
-          docker compose up -d --build;
+          docker compose up -f "urban_api/docker-compose.yml" -d --build;
           docker system prune --all --force;
           echo '--- LIST OF DOCKER CONTAINERS AFTER STARTING DOCKER CONTAINERS ---';
           docker ps;


### PR DESCRIPTION
Очень давно уже хочу попробовать написать какие-нибудь CI/CD пайплайны, чтобы перестать по несколько раз в день дергать Диму с обновлениями на 107 и остальных не заставлять лишний раз ждать, если он вдруг занят (да и зря я что ли какие-то курсы по девопсу проходил). 

В общем, накидал пока предварительный вариант, на своей машинке потестил — вроде работает. Конкретно здесь раннер просто внаглую подключается по SSH к хостам и занимается всякой магией с контейнерами. Думаю, на 509 и так сойдет, а на 107 можно какой-нибудь ручной апрув добавить, чтобы не травмировать фронт и всех остальных, кто активно с апишкой взаимодействует. 

Есть ещё вариант поинтереснее: пушить образ в докер хаб и через какой-нибудь простой вебхук, развернутый на машинках, автоматически подтягивать обновления с него. Звучит немного сложновато, прочитать можно тут: https://habr.com/ru/articles/476368/. 

Наверняка есть ещё какие-то варианты, было бы интересно послушать/почитать на этот счёт что-нибудь. 