### PR TITLE
Version 1.22 (urban_api 0.30)

### DIFF
--- a/idu_api/common/db/entities/projects/indicators.py
+++ b/idu_api/common/db/entities/projects/indicators.py
@@ -2,7 +2,20 @@
 
 from typing import Callable
 
-from sqlalchemy import TIMESTAMP, Column, Float, ForeignKey, Integer, Sequence, String, Table, Text, func, text
+from sqlalchemy import (
+    TIMESTAMP,
+    Column,
+    Float,
+    ForeignKey,
+    Integer,
+    Sequence,
+    String,
+    Table,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 
 from idu_api.common.db import metadata
@@ -51,6 +64,7 @@ projects_indicators_data = Table(
     Column("properties", JSONB(astext_type=Text()), nullable=False, server_default=text("'{}'::jsonb")),
     Column("created_at", TIMESTAMP(timezone=True), server_default=func.now(), nullable=False),
     Column("updated_at", TIMESTAMP(timezone=True), server_default=func.now(), nullable=False),
+    UniqueConstraint("scenario_id", "indicator_id", "territory_id", "hexagon_id"),
     schema="user_projects",
 )
 
@@ -64,6 +78,7 @@ Indicators data:
 - value float
 - comment string(2048)
 - information_source string(300)
+- properties jsonb
 - created_at timestamp
 - updated_at timestamp
 """

--- a/idu_api/common/db/migrator/versions/2024-12-03_ee3927f2af61_projects_indicators_values_unique.py
+++ b/idu_api/common/db/migrator/versions/2024-12-03_ee3927f2af61_projects_indicators_values_unique.py
@@ -1,0 +1,55 @@
+# pylint: disable=no-member,invalid-name,missing-function-docstring,too-many-statements
+"""projects indicators values unique
+
+Revision ID: ee3927f2af61
+Revises: ad9702dd19b7
+Create Date: 2024-12-03 19:23:43.132926
+
+"""
+from textwrap import dedent
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ee3927f2af61"
+down_revision: Union[str, None] = "ad9702dd19b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                WITH ranked_records AS (
+                    SELECT 
+                        indicator_value_id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY indicator_id, scenario_id, territory_id, hexagon_id
+                            ORDER BY updated_at DESC
+                        ) AS rnk
+                    FROM user_projects.indicators_data
+                )
+                DELETE FROM user_projects.indicators_data
+                WHERE indicator_value_id IN (
+                    SELECT indicator_value_id
+                    FROM ranked_records
+                    WHERE rnk > 1
+                );
+                """
+            )
+        )
+    )
+    op.create_unique_constraint(
+        "indicators_data_unique",
+        "indicators_data",
+        ["indicator_id", "scenario_id", "territory_id", "hexagon_id"],
+        schema="user_projects",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("indicators_data_unique", "indicators_data", schema="user_projects")

--- a/idu_api/common/db/migrator/versions/2024-12-03_f6e7924d483f_fix_list_label_triggers.py
+++ b/idu_api/common/db/migrator/versions/2024-12-03_f6e7924d483f_fix_list_label_triggers.py
@@ -1,0 +1,653 @@
+# pylint: disable=no-member,invalid-name,missing-function-docstring,too-many-statements
+"""fix list label triggers
+
+Revision ID: f6e7924d483f
+Revises: ee3927f2af61
+Create Date: 2024-12-03 19:36:56.349194
+
+"""
+from textwrap import dedent
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f6e7924d483f"
+down_revision: Union[str, None] = "ee3927f2af61"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # fix physical object function trigger
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE OR REPLACE FUNCTION public.trigger_update_po_function_list_label_on_update()
+                 RETURNS trigger
+                 LANGUAGE plpgsql
+                AS $function$
+                DECLARE
+                    parent_label TEXT;
+                    new_label TEXT;
+                    sibling_label TEXT;
+                    position INT := 0;
+                BEGIN
+                    -- Проверка на изменение list_label
+                    IF NEW.list_label <> OLD.list_label THEN
+                        -- Перенумеровываем дочерние функции для обновленной
+                        FOR sibling_label IN
+                            SELECT list_label FROM physical_object_functions_dict
+                            WHERE parent_id = NEW.physical_object_function_id
+                            ORDER BY  
+                                (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                 FROM unnest(string_to_array(list_label, '.')) AS part)
+                        LOOP
+                            position := position + 1;
+                            new_label := NEW.list_label || '.' || position;
+                
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+                
+                    -- Проверка на изменение родительской функции
+                    IF NEW.parent_id <> OLD.parent_id OR 
+                    NEW.parent_id IS NULL AND OLD.parent_id IS NOT NULL OR
+                    NEW.parent_id IS NOT NULL AND OLD.parent_id IS NULL
+                    THEN
+                        -- Если это корневая функция (нет родительской функции)
+                        IF NEW.parent_id IS NULL THEN
+                            new_label := (SELECT COUNT(*) FROM physical_object_functions_dict WHERE parent_id IS NULL)::TEXT;
+                
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE physical_object_function_id = NEW.physical_object_function_id;
+                        ELSE
+                            SELECT list_label INTO parent_label
+                            FROM physical_object_functions_dict
+                            WHERE physical_object_function_id = NEW.parent_id;
+                
+                            new_label := parent_label || '.' || (SELECT COUNT(*) FROM physical_object_functions_dict WHERE parent_id = NEW.parent_id)::TEXT;
+                
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE physical_object_function_id = NEW.physical_object_function_id;
+                        END IF;
+                
+                        -- Если старая функция была корневой
+                        IF OLD.parent_id IS NULL THEN
+                            FOR sibling_label IN
+                                SELECT list_label FROM physical_object_functions_dict
+                                WHERE parent_id IS NULL
+                                ORDER BY  
+                                    (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                     FROM unnest(string_to_array(list_label, '.')) AS part)
+                            LOOP
+                                position := position + 1;
+                                new_label := position::TEXT;
+                
+                                UPDATE physical_object_functions_dict
+                                SET list_label = new_label
+                                WHERE list_label = sibling_label;
+                            END LOOP;
+                        ELSE
+                            -- Получаем label родительской функции
+                            SELECT list_label INTO parent_label
+                            FROM physical_object_functions_dict
+                            WHERE physical_object_function_id = OLD.parent_id;
+                        END IF;
+                
+                        -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                        FOR sibling_label IN
+                            SELECT list_label FROM physical_object_functions_dict
+                            WHERE parent_id = OLD.parent_id
+                            ORDER BY  
+                                (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                 FROM unnest(string_to_array(list_label, '.')) AS part)
+                        LOOP
+                            position := position + 1;
+                            new_label := parent_label || '.' || position;
+                
+                            -- Обновляем list_label для функции на текущем уровне
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+                
+                    RETURN NEW;
+                END;
+                $function$
+                ;
+                """
+            )
+        )
+    )
+
+    # fix urban function trigger
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE OR REPLACE FUNCTION public.trigger_update_urban_function_list_label_on_update()
+                 RETURNS trigger
+                 LANGUAGE plpgsql
+                AS $function$
+                DECLARE
+                    parent_label TEXT;
+                    new_label TEXT;
+                    sibling_label TEXT;
+                    position INT := 0;
+                BEGIN
+                    -- Проверка на изменение list_label
+                    IF NEW.list_label <> OLD.list_label THEN
+                        -- Перенумеровываем дочерние функции для обновленной
+                        FOR sibling_label IN
+                            SELECT list_label FROM urban_functions_dict
+                            WHERE parent_urban_function_id = NEW.urban_function_id
+                            ORDER BY  
+                                (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                 FROM unnest(string_to_array(list_label, '.')) AS part)
+                        LOOP
+                            position := position + 1;
+                            new_label := NEW.list_label || '.' || position;
+                
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+                
+                    -- Проверка на изменение родительской функции
+                    IF NEW.parent_urban_function_id <> OLD.parent_urban_function_id OR 
+                    NEW.parent_urban_function_id IS NULL AND OLD.parent_urban_function_id IS NOT NULL OR
+                    NEW.parent_urban_function_id IS NOT NULL AND OLD.parent_urban_function_id IS NULL
+                    THEN
+                        -- Если это корневая функция (нет родительской функции)
+                        IF NEW.parent_urban_function_id IS NULL THEN
+                            new_label := (SELECT COUNT(*) FROM urban_functions_dict WHERE parent_urban_function_id IS NULL)::TEXT;
+                
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE urban_function_id = NEW.urban_function_id;
+                        ELSE
+                            SELECT list_label INTO parent_label
+                            FROM urban_functions_dict
+                            WHERE urban_function_id = NEW.parent_urban_function_id;
+                
+                            new_label := parent_label || '.' || (SELECT COUNT(*) FROM urban_functions_dict WHERE parent_urban_function_id = NEW.parent_urban_function_id)::TEXT;
+                
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE urban_function_id = NEW.urban_function_id;
+                        END IF;
+                
+                        -- Если старая функция была корневой
+                        IF OLD.parent_urban_function_id IS NULL THEN
+                            FOR sibling_label IN
+                                SELECT list_label FROM urban_functions_dict
+                                WHERE parent_urban_function_id IS NULL
+                                ORDER BY  
+                                    (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                     FROM unnest(string_to_array(list_label, '.')) AS part)
+                            LOOP
+                                position := position + 1;
+                                new_label := position::TEXT;
+                
+                                UPDATE urban_functions_dict
+                                SET list_label = new_label
+                                WHERE list_label = sibling_label;
+                            END LOOP;
+                        ELSE
+                            -- Получаем label родительской функции
+                            SELECT list_label INTO parent_label
+                            FROM urban_functions_dict
+                            WHERE urban_function_id = OLD.parent_urban_function_id;
+                        END IF;
+                
+                        -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                        FOR sibling_label IN
+                            SELECT list_label FROM urban_functions_dict
+                            WHERE parent_urban_function_id = OLD.parent_urban_function_id
+                            ORDER BY  
+                                (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                 FROM unnest(string_to_array(list_label, '.')) AS part)
+                        LOOP
+                            position := position + 1;
+                            new_label := parent_label || '.' || position;
+                
+                            -- Обновляем list_label для функции на текущем уровне
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+                
+                    RETURN NEW;
+                END;
+                $function$
+                ;
+                """
+            )
+        )
+    )
+
+    # fix indicators dict trigger
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE OR REPLACE FUNCTION public.trigger_update_indicator_list_label_on_update()
+                 RETURNS trigger
+                 LANGUAGE plpgsql
+                AS $function$
+                DECLARE
+                    parent_label TEXT;
+                    new_label TEXT;
+                    sibling_label TEXT;
+                    position INT := 0;
+                BEGIN
+                    -- Проверка на изменение list_label
+                    IF NEW.list_label <> OLD.list_label THEN
+                        -- Перенумеровываем дочерние функции для обновленной
+                        FOR sibling_label IN
+                            SELECT list_label FROM indicators_dict
+                            WHERE parent_id = NEW.indicator_id
+                            ORDER BY  
+                                (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                 FROM unnest(string_to_array(list_label, '.')) AS part)
+                        LOOP
+                            position := position + 1;
+                            new_label := NEW.list_label || '.' || position;
+                
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+                
+                    -- Проверка на изменение родительской функции
+                    IF NEW.parent_id <> OLD.parent_id OR 
+                    NEW.parent_id IS NULL AND OLD.parent_id IS NOT NULL OR
+                    NEW.parent_id IS NOT NULL AND OLD.parent_id IS NULL
+                    THEN
+                        -- Если это корневая функция (нет родительской функции)
+                        IF NEW.parent_id IS NULL THEN
+                            new_label := (SELECT COUNT(*) FROM indicators_dict WHERE parent_id IS NULL)::TEXT;
+                
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE indicator_id = NEW.indicator_id;
+                        ELSE
+                            SELECT list_label INTO parent_label
+                            FROM indicators_dict
+                            WHERE indicator_id = NEW.parent_id;
+                
+                            new_label := parent_label || '.' || (SELECT COUNT(*) FROM indicators_dict WHERE parent_id = NEW.parent_id)::TEXT;
+                
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE indicator_id = NEW.indicator_id;
+                        END IF;
+                
+                        -- Если старая функция была корневой
+                        IF OLD.parent_id IS NULL THEN
+                            FOR sibling_label IN
+                                SELECT list_label FROM indicators_dict
+                                WHERE parent_id IS NULL
+                                ORDER BY  
+                                    (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                     FROM unnest(string_to_array(list_label, '.')) AS part)
+                            LOOP
+                                position := position + 1;
+                                new_label := position::TEXT;
+                
+                                UPDATE indicators_dict
+                                SET list_label = new_label
+                                WHERE list_label = sibling_label;
+                            END LOOP;
+                        ELSE
+                            -- Получаем label родительской функции
+                            SELECT list_label INTO parent_label
+                            FROM indicators_dict
+                            WHERE indicator_id = OLD.parent_id;
+                        END IF;
+                
+                        -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                        FOR sibling_label IN
+                            SELECT list_label FROM indicators_dict
+                            WHERE parent_id = OLD.parent_id
+                            ORDER BY  
+                                (SELECT array_to_string(array_agg(LPAD(part, 4, '0')), '.') 
+                                 FROM unnest(string_to_array(list_label, '.')) AS part)
+                        LOOP
+                            position := position + 1;
+                            new_label := parent_label || '.' || position;
+                
+                            -- Обновляем list_label для функции на текущем уровне
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+                
+                    RETURN NEW;
+                END;
+                $function$
+                ;
+                """
+            )
+        )
+    )
+
+
+def downgrade() -> None:
+    # fix physical object function trigger
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE OR REPLACE FUNCTION public.trigger_update_po_function_list_label_on_update()
+                 RETURNS trigger
+                 LANGUAGE plpgsql
+                AS $function$
+                DECLARE
+                    parent_label TEXT;
+                    new_label TEXT;
+                    sibling_label TEXT;
+                    position INT := 0;
+                BEGIN
+                    -- Проверка на изменение list_label
+                    IF NEW.list_label <> OLD.list_label THEN
+                        -- Перенумеровываем дочерние функции для обновленной
+                        FOR sibling_label IN
+                            SELECT list_label FROM physical_object_functions_dict
+                            WHERE parent_id = NEW.physical_object_function_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := NEW.list_label || '.' || position;
+
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    -- Проверка на изменение родительской функции
+                    IF NEW.parent_id <> OLD.parent_id OR 
+                    NEW.parent_id IS NULL AND OLD.parent_id IS NOT NULL OR
+                    NEW.parent_id IS NOT NULL AND OLD.parent_id IS NULL
+                    THEN
+                        -- Если это корневая функция (нет родительской функции)
+                        IF NEW.parent_id IS NULL THEN
+                            new_label := (SELECT COUNT(*) FROM physical_object_functions_dict WHERE parent_id IS NULL)::TEXT;
+
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE physical_object_function_id = NEW.physical_object_function_id;
+                        ELSE
+                            SELECT list_label INTO parent_label
+                            FROM physical_object_functions_dict
+                            WHERE physical_object_function_id = NEW.parent_id;
+
+                            new_label := parent_label || '.' || (SELECT COUNT(*) FROM physical_object_functions_dict WHERE parent_id = NEW.parent_id)::TEXT;
+
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE physical_object_function_id = NEW.physical_object_function_id;
+                        END IF;
+
+                        -- Если старая функция была корневой
+                        IF OLD.parent_id IS NULL THEN
+                            FOR sibling_label IN
+                                SELECT list_label FROM physical_object_functions_dict
+                                WHERE parent_id IS NULL
+                                ORDER BY list_label
+                            LOOP
+                                position := position + 1;
+                                new_label := position::TEXT;
+
+                                UPDATE physical_object_functions_dict
+                                SET list_label = new_label
+                                WHERE list_label = sibling_label;
+                            END LOOP;
+                        ELSE
+                            -- Получаем label родительской функции
+                            SELECT list_label INTO parent_label
+                            FROM physical_object_functions_dict
+                            WHERE physical_object_function_id = OLD.parent_id;
+                        END IF;
+
+                        -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                        FOR sibling_label IN
+                            SELECT list_label FROM physical_object_functions_dict
+                            WHERE parent_id = OLD.parent_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := parent_label || '.' || position;
+
+                            -- Обновляем list_label для функции на текущем уровне
+                            UPDATE physical_object_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $function$
+                ;
+                """
+            )
+        )
+    )
+
+    # fix urban function trigger
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE OR REPLACE FUNCTION public.trigger_update_urban_function_list_label_on_update()
+                 RETURNS trigger
+                 LANGUAGE plpgsql
+                AS $function$
+                DECLARE
+                    parent_label TEXT;
+                    new_label TEXT;
+                    sibling_label TEXT;
+                    position INT := 0;
+                BEGIN
+                    -- Проверка на изменение list_label
+                    IF NEW.list_label <> OLD.list_label THEN
+                        -- Перенумеровываем дочерние функции для обновленной
+                        FOR sibling_label IN
+                            SELECT list_label FROM urban_functions_dict
+                            WHERE parent_urban_function_id = NEW.urban_function_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := NEW.list_label || '.' || position;
+
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    -- Проверка на изменение родительской функции
+                    IF NEW.parent_urban_function_id <> OLD.parent_urban_function_id OR 
+                    NEW.parent_urban_function_id IS NULL AND OLD.parent_urban_function_id IS NOT NULL OR
+                    NEW.parent_urban_function_id IS NOT NULL AND OLD.parent_urban_function_id IS NULL
+                    THEN
+                        -- Если это корневая функция (нет родительской функции)
+                        IF NEW.parent_urban_function_id IS NULL THEN
+                            new_label := (SELECT COUNT(*) FROM urban_functions_dict WHERE parent_urban_function_id IS NULL)::TEXT;
+
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE urban_function_id = NEW.urban_function_id;
+                        ELSE
+                            SELECT list_label INTO parent_label
+                            FROM urban_functions_dict
+                            WHERE urban_function_id = NEW.parent_urban_function_id;
+
+                            new_label := parent_label || '.' || (SELECT COUNT(*) FROM urban_functions_dict WHERE parent_urban_function_id = NEW.parent_urban_function_id)::TEXT;
+
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE urban_function_id = NEW.urban_function_id;
+                        END IF;
+
+                        -- Если старая функция была корневой
+                        IF OLD.parent_urban_function_id IS NULL THEN
+                            FOR sibling_label IN
+                                SELECT list_label FROM urban_functions_dict
+                                WHERE parent_urban_function_id IS NULL
+                                ORDER BY list_label
+                            LOOP
+                                position := position + 1;
+                                new_label := position::TEXT;
+
+                                UPDATE urban_functions_dict
+                                SET list_label = new_label
+                                WHERE list_label = sibling_label;
+                            END LOOP;
+                        ELSE
+                            -- Получаем label родительской функции
+                            SELECT list_label INTO parent_label
+                            FROM urban_functions_dict
+                            WHERE urban_function_id = OLD.parent_urban_function_id;
+                        END IF;
+
+                        -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                        FOR sibling_label IN
+                            SELECT list_label FROM urban_functions_dict
+                            WHERE parent_urban_function_id = OLD.parent_urban_function_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := parent_label || '.' || position;
+
+                            -- Обновляем list_label для функции на текущем уровне
+                            UPDATE urban_functions_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $function$
+                ;
+                """
+            )
+        )
+    )
+
+    # fix indicators dict trigger
+    op.execute(
+        sa.text(
+            dedent(
+                """
+                CREATE OR REPLACE FUNCTION public.trigger_update_indicator_list_label_on_update()
+                 RETURNS trigger
+                 LANGUAGE plpgsql
+                AS $function$
+                DECLARE
+                    parent_label TEXT;
+                    new_label TEXT;
+                    sibling_label TEXT;
+                    position INT := 0;
+                BEGIN
+                    -- Проверка на изменение list_label
+                    IF NEW.list_label <> OLD.list_label THEN
+                        -- Перенумеровываем дочерние функции для обновленной
+                        FOR sibling_label IN
+                            SELECT list_label FROM indicators_dict
+                            WHERE parent_id = NEW.indicator_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := NEW.list_label || '.' || position;
+
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    -- Проверка на изменение родительской функции
+                    IF NEW.parent_id <> OLD.parent_id OR 
+                    NEW.parent_id IS NULL AND OLD.parent_id IS NOT NULL OR
+                    NEW.parent_id IS NOT NULL AND OLD.parent_id IS NULL
+                    THEN
+                        -- Если это корневая функция (нет родительской функции)
+                        IF NEW.parent_id IS NULL THEN
+                            new_label := (SELECT COUNT(*) FROM indicators_dict WHERE parent_id IS NULL)::TEXT;
+
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE indicator_id = NEW.indicator_id;
+                        ELSE
+                            SELECT list_label INTO parent_label
+                            FROM indicators_dict
+                            WHERE indicator_id = NEW.parent_id;
+
+                            new_label := parent_label || '.' || (SELECT COUNT(*) FROM indicators_dict WHERE parent_id = NEW.parent_id)::TEXT;
+
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE indicator_id = NEW.indicator_id;
+                        END IF;
+
+                        -- Если старая функция была корневой
+                        IF OLD.parent_id IS NULL THEN
+                            FOR sibling_label IN
+                                SELECT list_label FROM indicators_dict
+                                WHERE parent_id IS NULL
+                                ORDER BY list_label
+                            LOOP
+                                position := position + 1;
+                                new_label := position::TEXT;
+
+                                UPDATE indicators_dict
+                                SET list_label = new_label
+                                WHERE list_label = sibling_label;
+                            END LOOP;
+                        ELSE
+                            -- Получаем label родительской функции
+                            SELECT list_label INTO parent_label
+                            FROM indicators_dict
+                            WHERE indicator_id = OLD.parent_id;
+                        END IF;
+
+                        -- Перенумеровываем оставшиеся функции на том же уровне, что и удаленная
+                        FOR sibling_label IN
+                            SELECT list_label FROM indicators_dict
+                            WHERE parent_id = OLD.parent_id
+                            ORDER BY list_label
+                        LOOP
+                            position := position + 1;
+                            new_label := parent_label || '.' || position;
+
+                            -- Обновляем list_label для функции на текущем уровне
+                            UPDATE indicators_dict
+                            SET list_label = new_label
+                            WHERE list_label = sibling_label;
+                        END LOOP;
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $function$
+                ;
+                """
+            )
+        )
+    )

--- a/idu_api/urban_api/dto/indicators.py
+++ b/idu_api/urban_api/dto/indicators.py
@@ -22,6 +22,7 @@ class IndicatorDTO:
 @dataclass(frozen=True)
 class IndicatorValueDTO:
     indicator_id: int
+    parent_id: int
     name_full: str
     measurement_unit_id: int | None
     measurement_unit_name: str | None
@@ -64,6 +65,7 @@ class ShortProjectIndicatorValueDTO:
 class ProjectIndicatorValueDTO:
     indicator_value_id: int
     indicator_id: int
+    parent_id: int
     name_full: str
     measurement_unit_id: int | None
     measurement_unit_name: str | None

--- a/idu_api/urban_api/handlers/v1/projects/functional_zones.py
+++ b/idu_api/urban_api/handlers/v1/projects/functional_zones.py
@@ -26,7 +26,6 @@ from idu_api.urban_api.utils.auth_client import get_user
     "/scenarios/{scenario_id}/functional_zone_sources",
     response_model=list[FunctionalZoneSource],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_functional_zone_sources_by_scenario_id(
     request: Request,
@@ -48,7 +47,6 @@ async def get_functional_zone_sources_by_scenario_id(
     "/scenarios/{scenario_id}/functional_zones",
     response_model=GeoJSONResponse[Feature[Geometry, ProjectProfileWithoutGeometry]],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_functional_zones_by_scenario_id(
     request: Request,
@@ -75,7 +73,6 @@ async def get_functional_zones_by_scenario_id(
     "/scenarios/{scenario_id}/context/functional_zone_sources",
     response_model=list[FunctionalZoneSource],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_context_functional_zone_sources_by_scenario_id(
     request: Request,
@@ -98,7 +95,6 @@ async def get_context_functional_zone_sources_by_scenario_id(
     "/scenarios/{scenario_id}/context/functional_zones",
     response_model=GeoJSONResponse[Feature[Geometry, FunctionalZoneWithoutGeometry]],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_context_functional_zones_by_scenario_id(
     request: Request,

--- a/idu_api/urban_api/handlers/v1/projects/functional_zones.py
+++ b/idu_api/urban_api/handlers/v1/projects/functional_zones.py
@@ -35,7 +35,8 @@ async def get_functional_zone_sources_by_scenario_id(
 ) -> list[FunctionalZoneSource]:
     """Get list of pairs (year, source) of functional zones by scenario identifier.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     sources = await user_project_service.get_functional_zones_sources_by_scenario_id(scenario_id, user.id)
@@ -59,7 +60,8 @@ async def get_functional_zones_by_scenario_id(
 ) -> GeoJSONResponse[Feature[Geometry, ProjectProfileWithoutGeometry]]:
     """Get functional zones by scenario identifier, year and source in geojson format.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     functional_zones = await user_project_service.get_functional_zones_by_scenario_id(
@@ -83,7 +85,8 @@ async def get_context_functional_zone_sources_by_scenario_id(
     """Get list of pairs (year, source) of functional zones
     by scenario identifier for 'context' of the project territory.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     sources = await user_project_service.get_context_functional_zones_sources_by_scenario_id(scenario_id, user.id)
@@ -108,7 +111,8 @@ async def get_context_functional_zones_by_scenario_id(
     """Get functional zones by scenario identifier, year and source
     for 'context' of the project territory in geojson format.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     functional_zones = await user_project_service.get_context_functional_zones_by_scenario_id(
@@ -132,7 +136,8 @@ async def add_scenario_functional_zones(
 ) -> list[ProjectProfile]:
     """Create new functional zones for given scenario and list of functional zones.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     functional_zones = await user_project_service.add_scenario_functional_zones(functional_zones, scenario_id, user.id)
@@ -155,7 +160,8 @@ async def put_scenario_functional_zone(
 ) -> ProjectProfile:
     """Update functional zone by all its attributes.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     functional_zone = await user_project_service.put_scenario_functional_zone(
@@ -180,7 +186,8 @@ async def patch_scenario_functional_zone(
 ) -> ProjectProfile:
     """Update functional zone by only given attributes.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     functional_zone = await user_project_service.patch_scenario_functional_zone(
@@ -202,7 +209,8 @@ async def delete_functional_zones_by_scenario_id(
 ) -> dict:
     """Delete all functional zones for given scenario
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_functional_zones_by_scenario_id(scenario_id, user.id)

--- a/idu_api/urban_api/handlers/v1/projects/geometries.py
+++ b/idu_api/urban_api/handlers/v1/projects/geometries.py
@@ -26,7 +26,6 @@ from idu_api.urban_api.utils.auth_client import get_user
     "/scenarios/{scenario_id}/geometries",
     response_model=GeoJSONResponse[Feature[Geometry, ScenarioGeometryAttributes]],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_geometries_by_scenario_id(
     request: Request,
@@ -58,7 +57,6 @@ async def get_geometries_by_scenario_id(
     "/scenarios/{scenario_id}/geometries_with_all_objects",
     response_model=GeoJSONResponse[Feature[Geometry, ScenarioAllObjects]],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_geometries_with_all_objects_by_scenario_id(
     request: Request,
@@ -94,7 +92,6 @@ async def get_geometries_with_all_objects_by_scenario_id(
     "/scenarios/{scenario_id}/context/geometries",
     response_model=GeoJSONResponse[Feature[Geometry, GeometryAttributes]],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_context_geometries_by_scenario_id(
     request: Request,
@@ -126,7 +123,6 @@ async def get_context_geometries_by_scenario_id(
     "/scenarios/{scenario_id}/context/geometries_with_all_objects",
     response_model=GeoJSONResponse[Feature[Geometry, AllObjects]],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_context_geometries_with_all_objects_by_scenario_id(
     request: Request,

--- a/idu_api/urban_api/handlers/v1/projects/geometries.py
+++ b/idu_api/urban_api/handlers/v1/projects/geometries.py
@@ -38,7 +38,10 @@ async def get_geometries_by_scenario_id(
 ) -> GeoJSONResponse[Feature[Geometry, ScenarioGeometryAttributes]]:
     """Get all geometries for given scenario in geojson format.
 
-    It could be specified by physical object and service."""
+    It could be specified by physical object and service.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     geometries = await user_project_service.get_geometries_by_scenario_id(
@@ -69,7 +72,10 @@ async def get_geometries_with_all_objects_by_scenario_id(
 ) -> GeoJSONResponse[Feature[Geometry, ScenarioAllObjects]]:
     """Get all geometries with lists of services and physical objects for given scenario in geojson format.
 
-    It could be specified by physical object type and service type."""
+    It could be specified by physical object type and service type.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     geometries = await user_project_service.get_geometries_with_all_objects_by_scenario_id(
@@ -100,7 +106,10 @@ async def get_context_geometries_by_scenario_id(
 ) -> GeoJSONResponse[Feature[Geometry, GeometryAttributes]]:
     """Get all geometries for context of the project territory for given scenario in geojson format.
 
-    It could be specified by physical object and service."""
+    It could be specified by physical object and service.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     geometries = await user_project_service.get_context_geometries_by_scenario_id(
@@ -132,7 +141,10 @@ async def get_context_geometries_with_all_objects_by_scenario_id(
     """Get all geometries with lists of services and physical objects for context of the project territory
      for given scenario in geojson format.
 
-    It could be specified by physical object type and service type."""
+    It could be specified by physical object type and service type.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     geometries = await user_project_service.get_context_geometries_with_all_objects_by_scenario_id(
@@ -161,7 +173,10 @@ async def put_object_geometry(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioObjectGeometry:
-    """Update scenario object geometry - all attributes."""
+    """Update scenario object geometry - all attributes.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     object_geometry_dto = await user_project_service.put_object_geometry(
@@ -189,7 +204,10 @@ async def patch_object_geometry(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioObjectGeometry:
-    """Update scenario object geometry - only given fields."""
+    """Update scenario object geometry - only given fields.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     object_geometry_dto = await user_project_service.patch_object_geometry(
@@ -216,7 +234,10 @@ async def delete_object_geometry(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> dict:
-    """Delete scenario object geometry by given id."""
+    """Delete scenario object geometry by given identifier.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_object_geometry(

--- a/idu_api/urban_api/handlers/v1/projects/indicators.py
+++ b/idu_api/urban_api/handlers/v1/projects/indicators.py
@@ -34,10 +34,12 @@ async def get_project_indicators_values_by_scenario_id(
     hexagon_id: int | None = Query(None, description="to filter by hexagon identifier"),
     user: UserDTO = Depends(get_user),
 ) -> list[ProjectIndicatorValue]:
-    """Get project's indicators values for given scenario
-    if relevant project is public or if you're the project owner.
+    """Get project's indicators values for given scenario.
 
-    It could be specified by indicator identifiers, indicators group, territory and hexagon."""
+    It could be specified by indicator identifiers, indicators group, territory and hexagon.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     indicators = await user_project_service.get_projects_indicators_values_by_scenario_id(
@@ -63,8 +65,10 @@ async def get_project_indicator_value_by_id(
     indicator_value_id: int = Path(..., description="indicator identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ProjectIndicatorValue:
-    """Get project's specific indicator values for given scenario
-    if relevant project is public or if you're the project owner."""
+    """Get project's specific indicator values for given scenario.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     indicator_value = await user_project_service.get_project_indicator_value_by_id(indicator_value_id, user.id)
@@ -81,7 +85,10 @@ async def get_project_indicator_value_by_id(
 async def add_project_indicator(
     request: Request, projects_indicator: ProjectIndicatorValuePost, user: UserDTO = Depends(get_user)
 ) -> ProjectIndicatorValue:
-    """Add a new project's indicator value."""
+    """Add a new project's indicator value.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     indicator = await user_project_service.add_projects_indicator_value(projects_indicator, user.id)
@@ -90,7 +97,7 @@ async def add_project_indicator(
 
 
 @projects_router.put(
-    "/scenarios/indicators_values/{indicator_value_id}",
+    "/scenarios/indicators_values",
     response_model=ProjectIndicatorValue,
     status_code=status.HTTP_200_OK,
     dependencies=[Security(HTTPBearer())],
@@ -98,13 +105,16 @@ async def add_project_indicator(
 async def put_project_indicator(
     request: Request,
     projects_indicator: ProjectIndicatorValuePut,
-    indicator_value_id: int = Path(..., description="indicator value identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ProjectIndicatorValue:
-    """Put project's indicator value."""
+    """Update project's indicator value if indicator value with such attributes already exists
+    or create new indicator value for given scenario.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
-    indicator = await user_project_service.put_projects_indicator_value(projects_indicator, indicator_value_id, user.id)
+    indicator = await user_project_service.put_projects_indicator_value(projects_indicator, user.id)
 
     return ProjectIndicatorValue.from_dto(indicator)
 
@@ -121,7 +131,10 @@ async def patch_project_indicator(
     indicator_value_id: int = Path(..., description="indicator value identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ProjectIndicatorValue:
-    """Patch project's indicator value."""
+    """Update project's indicator value - only given fields.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     indicator = await user_project_service.patch_projects_indicator_value(
@@ -141,7 +154,10 @@ async def delete_project_indicators_values_by_scenario_id(
     scenario_id: int = Path(..., description="scenario identifier"),
     user: UserDTO = Depends(get_user),
 ) -> dict:
-    """Delete all project's indicators values for given scenario if you're the project owner."""
+    """Delete all project's indicators values for given scenario.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_projects_indicators_values_by_scenario_id(scenario_id, user.id)
@@ -157,7 +173,10 @@ async def delete_project_indicator_by_id(
     indicator_value_id: int = Path(..., description="indicator value identifier"),
     user: UserDTO = Depends(get_user),
 ) -> dict:
-    """Delete specific project's indicator values for given scenario if you're the project owner."""
+    """Delete specific project's indicator values for given scenario.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_project_indicator_value_by_id(indicator_value_id, user.id)
@@ -178,7 +197,10 @@ async def get_hexagons_with_indicators_values_by_territory_id(
     user: UserDTO = Depends(get_user),
 ) -> GeoJSONResponse[Feature[Geometry, HexagonWithIndicators]]:
     """Get list of hexagons for a given territory and regional scenario
-    with indicators values in properties in geojson format."""
+    with indicators values in properties in geojson format.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     hexagons = await user_project_service.get_hexagons_with_indicators_by_scenario_id(

--- a/idu_api/urban_api/handlers/v1/projects/indicators.py
+++ b/idu_api/urban_api/handlers/v1/projects/indicators.py
@@ -23,7 +23,6 @@ from idu_api.urban_api.utils.auth_client import get_user
     "/scenarios/{scenario_id}/indicators_values",
     response_model=list[ProjectIndicatorValue],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_project_indicators_values_by_scenario_id(
     request: Request,
@@ -58,7 +57,6 @@ async def get_project_indicators_values_by_scenario_id(
     "/scenarios/indicators_values/{indicator_value_id}",
     response_model=ProjectIndicatorValue,
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_project_indicator_value_by_id(
     request: Request,
@@ -186,7 +184,6 @@ async def delete_project_indicator_by_id(
     "/scenarios/{scenario_id}/indicators_values/hexagons",
     response_model=GeoJSONResponse[Feature[Geometry, HexagonWithIndicators]],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_hexagons_with_indicators_values_by_territory_id(
     request: Request,

--- a/idu_api/urban_api/handlers/v1/projects/physical_objects.py
+++ b/idu_api/urban_api/handlers/v1/projects/physical_objects.py
@@ -33,7 +33,10 @@ async def get_physical_objects_by_scenario_id(
 ) -> list[ScenarioPhysicalObject]:
     """Get list of physical objects for given scenario.
 
-    It could be specified by physical object type and physical object function."""
+    It could be specified by physical object type and physical object function.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     physical_objects = await user_project_service.get_physical_objects_by_scenario_id(
@@ -61,7 +64,10 @@ async def get_context_physical_objects_by_scenario_id(
 ) -> list[PhysicalObjectsData]:
     """Get list of physical objects for context of the project territory for given scenario.
 
-    It could be specified by physical object type and physical object function."""
+    It could be specified by physical object type and physical object function.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     physical_objects = await user_project_service.get_context_physical_objects_by_scenario_id(
@@ -86,7 +92,10 @@ async def add_physical_object_with_geometry(
     scenario_id: int = Path(..., description="scenario identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioUrbanObject:
-    """Create new physical object and geometry for given scenario."""
+    """Create new physical object and geometry for given scenario.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     urban_object = await user_project_service.add_physical_object_with_geometry(
@@ -112,7 +121,10 @@ async def update_physical_objects_by_function_id(
     user: UserDTO = Depends(get_user),
 ) -> list[ScenarioUrbanObject]:
     """Delete all physical objects by physical object function identifier
-    and upload new objects with the same function for given scenario."""
+    and upload new objects with the same function for given scenario.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     urban_objects = await user_project_service.update_physical_objects_by_function_id(
@@ -139,7 +151,10 @@ async def put_physical_object(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioPhysicalObject:
-    """Update scenario physical object - all attributes."""
+    """Update scenario physical object - all attributes.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     physical_object_dto = await user_project_service.put_physical_object(
@@ -167,7 +182,10 @@ async def patch_physical_object(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioPhysicalObject:
-    """Update scenario physical object - only given fields."""
+    """Update scenario physical object - only given fields.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     physical_object_dto = await user_project_service.patch_physical_object(
@@ -194,7 +212,10 @@ async def delete_physical_object(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> dict:
-    """Delete scenario physical object by given id."""
+    """Delete scenario physical object by given identifier.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_physical_object(

--- a/idu_api/urban_api/handlers/v1/projects/physical_objects.py
+++ b/idu_api/urban_api/handlers/v1/projects/physical_objects.py
@@ -22,7 +22,6 @@ from idu_api.urban_api.utils.auth_client import get_user
     "/scenarios/{scenario_id}/physical_objects",
     response_model=list[ScenarioPhysicalObject],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_physical_objects_by_scenario_id(
     request: Request,
@@ -53,7 +52,6 @@ async def get_physical_objects_by_scenario_id(
     "/scenarios/{scenario_id}/context/physical_objects",
     response_model=list[PhysicalObjectsData],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_context_physical_objects_by_scenario_id(
     request: Request,

--- a/idu_api/urban_api/handlers/v1/projects/projects.py
+++ b/idu_api/urban_api/handlers/v1/projects/projects.py
@@ -34,7 +34,9 @@ async def get_project_by_id(
     project_id: int = Path(..., description="project identifier"),
     user: UserDTO = Depends(get_user),
 ) -> Project:
-    """Get a project by identifier."""
+    """Get a project by identifier.
+
+    You must be the owner of the relevant project or the project must be publicly available."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     project_dto = await user_project_service.get_project_by_id(project_id, user.id)
@@ -53,7 +55,9 @@ async def get_project_territory_by_project_id(
     project_id: int = Path(..., description="project identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ProjectTerritory:
-    """Get territory info by project identifier."""
+    """Get territory info by project identifier.
+
+    You must be the owner of the relevant project or the project must be publicly available."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     project_territory_dto = await user_project_service.get_project_territory_by_id(project_id, user.id)
@@ -232,7 +236,9 @@ async def put_project(
     project_id: int = Path(..., description="project identifier"),
     user: UserDTO = Depends(get_user),
 ) -> Project:
-    """Update a project by setting all of its attributes."""
+    """Update a project by setting all of its attributes.
+
+    You must be the owner of the relevant project."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     project_dto = await user_project_service.put_project(project, project_id, user.id)
@@ -252,7 +258,9 @@ async def patch_project(
     project_id: int = Path(..., description="project identifier"),
     user: UserDTO = Depends(get_user),
 ) -> Project:
-    """Update a project by setting given attributes."""
+    """Update a project by setting given attributes.
+
+    You must be the owner of the relevant project."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     project_dto = await user_project_service.patch_project(project, project_id, user.id)
@@ -271,7 +279,9 @@ async def delete_project(
     minio_client: AsyncMinioClient = Depends(get_minio_client),
     user: UserDTO = Depends(get_user),
 ) -> dict:
-    """Delete a project."""
+    """Delete a project.
+
+    You must be the owner of the relevant project."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_project(project_id, minio_client, user.id)
@@ -290,7 +300,9 @@ async def upload_project_image(
     user: UserDTO = Depends(get_user),
     minio_client: AsyncMinioClient = Depends(get_minio_client),
 ) -> MinioImagesURL:
-    """Upload project image to minio."""
+    """Upload project image to minio.
+
+    You must be the owner of the relevant project."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     if not file.content_type.startswith("image/"):
@@ -312,7 +324,9 @@ async def get_full_project_image(
     user: UserDTO = Depends(get_user),
     minio_client: AsyncMinioClient = Depends(get_minio_client),
 ) -> StreamingResponse:
-    """Get full image for given project."""
+    """Get full image for given project.
+
+    You must be the owner of the relevant project or the project must be publicly available."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     image_stream = await user_project_service.get_full_project_image(minio_client, project_id, user.id)
@@ -331,7 +345,9 @@ async def get_preview_project_image(
     user: UserDTO = Depends(get_user),
     minio_client: AsyncMinioClient = Depends(get_minio_client),
 ) -> StreamingResponse:
-    """Get preview image for given project."""
+    """Get preview image for given project.
+
+    You must be the owner of the relevant project or the project must be publicly available."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     image_stream = await user_project_service.get_preview_project_image(minio_client, project_id, user.id)
@@ -351,7 +367,9 @@ async def get_full_project_image_url(
     user: UserDTO = Depends(get_user),
     minio_client: AsyncMinioClient = Depends(get_minio_client),
 ) -> str:
-    """Get full image url for given project."""
+    """Get full image url for given project.
+
+    You must be the owner of the relevant project or the project must be publicly available."""
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.get_full_project_image_url(minio_client, project_id, user.id)

--- a/idu_api/urban_api/handlers/v1/projects/projects.py
+++ b/idu_api/urban_api/handlers/v1/projects/projects.py
@@ -27,7 +27,6 @@ from idu_api.urban_api.utils.minio_client import AsyncMinioClient, get_minio_cli
     "/projects/{project_id}",
     response_model=Project,
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_project_by_id(
     request: Request,
@@ -48,7 +47,6 @@ async def get_project_by_id(
     "/projects/{project_id}/territory",
     response_model=ProjectTerritory,
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_project_territory_by_project_id(
     request: Request,
@@ -69,7 +67,6 @@ async def get_project_territory_by_project_id(
     "/projects/{project_id}/scenarios",
     response_model=list[ScenariosData],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_scenarios_by_project_id(
     request: Request,
@@ -238,7 +235,8 @@ async def put_project(
 ) -> Project:
     """Update a project by setting all of its attributes.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     project_dto = await user_project_service.put_project(project, project_id, user.id)
@@ -260,7 +258,8 @@ async def patch_project(
 ) -> Project:
     """Update a project by setting given attributes.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     project_dto = await user_project_service.patch_project(project, project_id, user.id)
@@ -281,7 +280,8 @@ async def delete_project(
 ) -> dict:
     """Delete a project.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_project(project_id, minio_client, user.id)
@@ -302,7 +302,8 @@ async def upload_project_image(
 ) -> MinioImagesURL:
     """Upload project image to minio.
 
-    You must be the owner of the relevant project."""
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     if not file.content_type.startswith("image/"):
@@ -316,7 +317,6 @@ async def upload_project_image(
 @projects_router.get(
     "/projects/{project_id}/image",
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_full_project_image(
     request: Request,
@@ -326,7 +326,8 @@ async def get_full_project_image(
 ) -> StreamingResponse:
     """Get full image for given project.
 
-    You must be the owner of the relevant project or the project must be publicly available."""
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     image_stream = await user_project_service.get_full_project_image(minio_client, project_id, user.id)
@@ -337,7 +338,6 @@ async def get_full_project_image(
 @projects_router.get(
     "/projects/{project_id}/preview",
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_preview_project_image(
     request: Request,
@@ -347,7 +347,8 @@ async def get_preview_project_image(
 ) -> StreamingResponse:
     """Get preview image for given project.
 
-    You must be the owner of the relevant project or the project must be publicly available."""
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     image_stream = await user_project_service.get_preview_project_image(minio_client, project_id, user.id)
@@ -359,7 +360,6 @@ async def get_preview_project_image(
     "/projects/{project_id}/image_url",
     response_model=str,
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_full_project_image_url(
     request: Request,
@@ -369,7 +369,8 @@ async def get_full_project_image_url(
 ) -> str:
     """Get full image url for given project.
 
-    You must be the owner of the relevant project or the project must be publicly available."""
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.get_full_project_image_url(minio_client, project_id, user.id)

--- a/idu_api/urban_api/handlers/v1/projects/scenarios.py
+++ b/idu_api/urban_api/handlers/v1/projects/scenarios.py
@@ -20,7 +20,6 @@ from idu_api.urban_api.utils.auth_client import get_user
     "/scenarios/{scenario_id}",
     response_model=ScenariosData,
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_scenario_by_id(
     request: Request,

--- a/idu_api/urban_api/handlers/v1/projects/scenarios.py
+++ b/idu_api/urban_api/handlers/v1/projects/scenarios.py
@@ -27,7 +27,10 @@ async def get_scenario_by_id(
     scenario_id: int = Path(..., description="scenario identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ScenariosData:
-    """Get scenario by identifier if project is public or if you're the project owner."""
+    """Get scenario by identifier.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     scenario = await user_project_service.get_scenario_by_id(scenario_id, user.id)
@@ -42,13 +45,36 @@ async def get_scenario_by_id(
     dependencies=[Security(HTTPBearer())],
 )
 async def add_scenario(request: Request, scenario: ScenariosPost, user: UserDTO = Depends(get_user)) -> ScenariosData:
-    """Create a new scenario for given project.
+    """Create a new scenario from the base scenario for given project.
 
     You must be the owner of the relevant project.
     """
     user_project_service: UserProjectService = request.state.user_project_service
 
     scenario = await user_project_service.add_scenario(scenario, user.id)
+
+    return ScenariosData.from_dto(scenario)
+
+
+@projects_router.post(
+    "/scenarios/{scenario_id}",
+    response_model=ScenariosData,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Security(HTTPBearer())],
+)
+async def copy_scenario(
+    request: Request,
+    scenario: ScenariosPost,
+    scenario_id: int = Path(..., description="another scenario identifier"),
+    user: UserDTO = Depends(get_user),
+) -> ScenariosData:
+    """Create a new scenario from another scenario (copy) by its identifier for given project.
+
+    You must be the owner of the relevant project.
+    """
+    user_project_service: UserProjectService = request.state.user_project_service
+
+    scenario = await user_project_service.copy_scenario(scenario, scenario_id, user.id)
 
     return ScenariosData.from_dto(scenario)
 
@@ -65,7 +91,7 @@ async def put_scenario(
     scenario_id: int = Path(..., description="scenario identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ScenariosData:
-    """Update a scenario by setting all of its attributes.
+    """Update a scenario object - all attributes.
 
     You must be the owner of the relevant project.
     """
@@ -88,7 +114,7 @@ async def patch_scenario(
     scenario_id: int = Path(..., description="scenario identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ScenariosData:
-    """Update a scenario by setting given attributes.
+    """Update a scenario - only given fields.
 
     You must be the owner of the relevant project.
     """

--- a/idu_api/urban_api/handlers/v1/projects/services.py
+++ b/idu_api/urban_api/handlers/v1/projects/services.py
@@ -22,7 +22,6 @@ from idu_api.urban_api.utils.auth_client import get_user
     "/scenarios/{scenario_id}/services",
     response_model=list[ScenarioService],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_services_by_scenario_id(
     request: Request,
@@ -53,7 +52,6 @@ async def get_services_by_scenario_id(
     "/scenarios/{scenario_id}/context/services",
     response_model=list[ServicesData],
     status_code=status.HTTP_200_OK,
-    dependencies=[Security(HTTPBearer())],
 )
 async def get_context_services_by_scenario_id(
     request: Request,

--- a/idu_api/urban_api/handlers/v1/projects/services.py
+++ b/idu_api/urban_api/handlers/v1/projects/services.py
@@ -33,7 +33,10 @@ async def get_services_by_scenario_id(
 ) -> list[ScenarioService]:
     """Get list of services for given scenario.
 
-    It could be specified by service type and urban function."""
+    It could be specified by service type and urban function.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     services = await user_project_service.get_services_by_scenario_id(
@@ -61,7 +64,10 @@ async def get_context_services_by_scenario_id(
 ) -> list[ServicesData]:
     """Get list of services for context of the project territory for given scenario.
 
-    It could be specified by service type and urban function."""
+    It could be specified by service type and urban function.
+
+    You must be the owner of the relevant project or the project must be publicly available.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     services = await user_project_service.get_context_services_by_scenario_id(
@@ -86,7 +92,10 @@ async def add_service(
     scenario_id: int = Path(..., description="scenario identifier"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioUrbanObject:
-    """Create new service for given scenario, physical object and geometry."""
+    """Create new service for given scenario, physical object and geometry.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     urban_object = await user_project_service.add_service(service, scenario_id, user.id)
@@ -108,7 +117,10 @@ async def put_service(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioService:
-    """Update scenario service - all attributes."""
+    """Update scenario service - all attributes.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     service_dto = await user_project_service.put_service(service, scenario_id, service_id, is_scenario_object, user.id)
@@ -130,7 +142,10 @@ async def patch_service(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> ScenarioService:
-    """Update scenario service - only given fields."""
+    """Update scenario service - only given fields.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     service_dto = await user_project_service.patch_service(
@@ -157,7 +172,10 @@ async def delete_service(
     is_scenario_object: bool = Query(..., description="to determine scenario object"),
     user: UserDTO = Depends(get_user),
 ) -> dict:
-    """Delete scenario service by given id."""
+    """Delete scenario service by given identifier.
+
+    You must be the owner of the relevant project.
+    """
     user_project_service: UserProjectService = request.state.user_project_service
 
     return await user_project_service.delete_service(scenario_id, service_id, is_scenario_object, user.id)

--- a/idu_api/urban_api/logic/impl/helpers/indicators.py
+++ b/idu_api/urban_api/logic/impl/helpers/indicators.py
@@ -494,6 +494,7 @@ async def get_indicator_value_by_id_from_db(
     statement = (
         select(
             territory_indicators_data,
+            indicators_dict.c.parent_id,
             indicators_dict.c.name_full,
             indicators_dict.c.level,
             indicators_dict.c.list_label,
@@ -614,6 +615,7 @@ async def get_indicator_values_by_id_from_db(
     statement = (
         select(
             territory_indicators_data,
+            indicators_dict.c.parent_id,
             indicators_dict.c.name_full,
             indicators_dict.c.level,
             indicators_dict.c.list_label,

--- a/idu_api/urban_api/logic/impl/helpers/projects_functional_zones.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_functional_zones.py
@@ -52,7 +52,7 @@ async def get_functional_zones_sources_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     statement = (
@@ -82,7 +82,7 @@ async def get_functional_zones_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     statement = (
@@ -139,7 +139,7 @@ async def get_context_functional_zones_sources_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     context_territories = select(
@@ -219,7 +219,7 @@ async def get_context_functional_zones_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     context_territories = select(

--- a/idu_api/urban_api/logic/impl/helpers/projects_geometries.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_geometries.py
@@ -64,7 +64,7 @@ async def get_geometries_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id or project.public:
         raise AccessDeniedError(project_id, "project")
 
     project_geometry = (
@@ -276,7 +276,7 @@ async def get_geometries_with_all_objects_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id or project.public:
         raise AccessDeniedError(project_id, "project")
 
     project_geometry = (
@@ -730,7 +730,7 @@ async def get_context_geometries_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id or project.public:
         raise AccessDeniedError(project_id, "project")
 
     context_territories = select(
@@ -855,7 +855,7 @@ async def get_context_geometries_with_all_objects_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id or project.public:
         raise AccessDeniedError(project_id, "project")
 
     context_territories = select(

--- a/idu_api/urban_api/logic/impl/helpers/projects_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_objects.py
@@ -66,7 +66,7 @@ async def get_project_by_id_from_db(conn: AsyncConnection, project_id: int, user
 
     if result is None:
         raise EntityNotFoundById(project_id, "project")
-    if result.user_id != user_id and result.public is False:
+    if result.user_id != user_id and not result.public:
         raise AccessDeniedError(project_id, "project")
 
     return ProjectDTO(**result)
@@ -81,7 +81,7 @@ async def get_project_territory_by_id_from_db(
     result_for_project = (await conn.execute(statement_for_project)).mappings().one_or_none()
     if result_for_project is None:
         raise EntityNotFoundById(project_id, "project")
-    if result_for_project.user_id != user_id and result_for_project.public is False:
+    if result_for_project.user_id != user_id and not result_for_project.public:
         raise AccessDeniedError(project_id, "project")
 
     statement = (
@@ -703,10 +703,9 @@ async def upload_project_image_to_minio(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     result = (await conn.execute(statement)).mappings().one_or_none()
-
     if result is None:
         raise EntityNotFoundById(project_id, "project")
-    if result.user_id != user_id and result.public is False:
+    if result.user_id != user_id:
         raise AccessDeniedError(project_id, "project")
 
     try:
@@ -768,7 +767,7 @@ async def get_full_project_image_from_minio(
 
     if result is None:
         raise EntityNotFoundById(project_id, "project")
-    if result.user_id != user_id and result.public is False:
+    if result.user_id != user_id and not result.public:
         raise AccessDeniedError(project_id, "project")
 
     return await minio_client.get_file(f"projects/{project_id}/image.jpg")
@@ -784,7 +783,7 @@ async def get_preview_project_image_from_minio(
 
     if result is None:
         raise EntityNotFoundById(project_id, "project")
-    if result.user_id != user_id and result.public is False:
+    if result.user_id != user_id and not result.public:
         raise AccessDeniedError(project_id, "project")
 
     return await minio_client.get_file(f"projects/{project_id}/preview.png")
@@ -800,7 +799,7 @@ async def get_full_project_image_url_from_minio(
 
     if result is None:
         raise EntityNotFoundById(project_id, "project")
-    if result.user_id != user_id and result.public is False:
+    if result.user_id != user_id and not result.public:
         raise AccessDeniedError(project_id, "project")
 
     return await minio_client.get_presigned_url(f"projects/{project_id}/image.jpg")

--- a/idu_api/urban_api/logic/impl/helpers/projects_physical_objects.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_physical_objects.py
@@ -45,7 +45,7 @@ async def get_physical_objects_by_scenario_id(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     project_geometry = (
@@ -277,7 +277,7 @@ async def get_context_physical_objects_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     context_territories = select(

--- a/idu_api/urban_api/logic/impl/helpers/projects_services.py
+++ b/idu_api/urban_api/logic/impl/helpers/projects_services.py
@@ -49,7 +49,7 @@ async def get_services_by_scenario_id(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     project_geometry = (
@@ -268,7 +268,7 @@ async def get_context_services_by_scenario_id_from_db(
 
     statement = select(projects_data).where(projects_data.c.project_id == project_id)
     project = (await conn.execute(statement)).mappings().one_or_none()
-    if project.user_id != user_id:
+    if project.user_id != user_id and not project.public:
         raise AccessDeniedError(project_id, "project")
 
     context_territories = select(

--- a/idu_api/urban_api/logic/impl/helpers/territories_indicators.py
+++ b/idu_api/urban_api/logic/impl/helpers/territories_indicators.py
@@ -92,6 +92,7 @@ async def get_indicator_values_by_territory_id_from_db(
         statement = (
             select(
                 territory_indicators_data,
+                indicators_dict.c.parent_id,
                 indicators_dict.c.name_full,
                 indicators_dict.c.level,
                 indicators_dict.c.list_label,
@@ -130,6 +131,7 @@ async def get_indicator_values_by_territory_id_from_db(
         statement = (
             select(
                 territory_indicators_data,
+                indicators_dict.c.parent_id,
                 indicators_dict.c.name_full,
                 indicators_dict.c.level,
                 indicators_dict.c.list_label,

--- a/idu_api/urban_api/logic/impl/projects.py
+++ b/idu_api/urban_api/logic/impl/projects.py
@@ -82,6 +82,7 @@ from idu_api.urban_api.logic.impl.helpers.projects_physical_objects import (
 )
 from idu_api.urban_api.logic.impl.helpers.projects_scenarios import (
     add_new_scenario_to_db,
+    copy_scenario_to_db,
     delete_scenario_from_db,
     get_scenario_by_id_from_db,
     get_scenarios_by_project_id_from_db,
@@ -201,6 +202,9 @@ class UserProjectServiceImpl(UserProjectService):
 
     async def add_scenario(self, scenario: ScenariosPost, user_id: str) -> ScenarioDTO:
         return await add_new_scenario_to_db(self._conn, scenario, user_id)
+
+    async def copy_scenario(self, scenario: ScenariosPost, scenario_id: int, user_id: str) -> ScenarioDTO:
+        return await copy_scenario_to_db(self._conn, scenario, scenario_id, user_id)
 
     async def put_scenario(self, scenario: ScenariosPut, scenario_id: int, user_id) -> ScenarioDTO:
         return await put_scenario_to_db(self._conn, scenario, scenario_id, user_id)
@@ -490,9 +494,9 @@ class UserProjectServiceImpl(UserProjectService):
         return await add_project_indicator_value_to_db(self._conn, projects_indicator, user_id)
 
     async def put_projects_indicator_value(
-        self, projects_indicator: ProjectIndicatorValuePut, indicator_value_id: int, user_id: str
+        self, projects_indicator: ProjectIndicatorValuePut, user_id: str
     ) -> ProjectIndicatorValueDTO:
-        return await put_project_indicator_value_to_db(self._conn, projects_indicator, indicator_value_id, user_id)
+        return await put_project_indicator_value_to_db(self._conn, projects_indicator, user_id)
 
     async def patch_projects_indicator_value(
         self, projects_indicator: ProjectIndicatorValuePatch, indicator_value_id: int, user_id: str

--- a/idu_api/urban_api/logic/impl/projects.py
+++ b/idu_api/urban_api/logic/impl/projects.py
@@ -132,10 +132,10 @@ class UserProjectServiceImpl(UserProjectService):
     def __init__(self, conn: AsyncConnection):
         self._conn = conn
 
-    async def get_project_by_id(self, project_id: int, user_id: str) -> ProjectDTO:
+    async def get_project_by_id(self, project_id: int, user_id: str | None) -> ProjectDTO:
         return await get_project_by_id_from_db(self._conn, project_id, user_id)
 
-    async def get_project_territory_by_id(self, project_id: int, user_id: str) -> ProjectTerritoryDTO:
+    async def get_project_territory_by_id(self, project_id: int, user_id: str | None) -> ProjectTerritoryDTO:
         return await get_project_territory_by_id_from_db(self._conn, project_id, user_id)
 
     async def get_all_available_projects(
@@ -183,21 +183,25 @@ class UserProjectServiceImpl(UserProjectService):
     ) -> dict:
         return await upload_project_image_to_minio(self._conn, minio_client, project_id, user_id, file)
 
-    async def get_full_project_image(self, minio_client: AsyncMinioClient, project_id: int, user_id: str) -> io.BytesIO:
+    async def get_full_project_image(
+        self, minio_client: AsyncMinioClient, project_id: int, user_id: str | None
+    ) -> io.BytesIO:
         return await get_full_project_image_from_minio(self._conn, minio_client, project_id, user_id)
 
     async def get_preview_project_image(
-        self, minio_client: AsyncMinioClient, project_id: int, user_id: str
+        self, minio_client: AsyncMinioClient, project_id: int, user_id: str | None
     ) -> io.BytesIO:
         return await get_preview_project_image_from_minio(self._conn, minio_client, project_id, user_id)
 
-    async def get_full_project_image_url(self, minio_client: AsyncMinioClient, project_id: int, user_id: str) -> str:
+    async def get_full_project_image_url(
+        self, minio_client: AsyncMinioClient, project_id: int, user_id: str | None
+    ) -> str:
         return await get_full_project_image_url_from_minio(self._conn, minio_client, project_id, user_id)
 
-    async def get_scenarios_by_project_id(self, project_id: int, user_id) -> list[ScenarioDTO]:
+    async def get_scenarios_by_project_id(self, project_id: int, user_id: str | None) -> list[ScenarioDTO]:
         return await get_scenarios_by_project_id_from_db(self._conn, project_id, user_id)
 
-    async def get_scenario_by_id(self, scenario_id: int, user_id) -> ScenarioDTO:
+    async def get_scenario_by_id(self, scenario_id: int, user_id: str | None) -> ScenarioDTO:
         return await get_scenario_by_id_from_db(self._conn, scenario_id, user_id)
 
     async def add_scenario(self, scenario: ScenariosPost, user_id: str) -> ScenarioDTO:
@@ -218,7 +222,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_physical_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         physical_object_function_id: int | None,
     ) -> list[ScenarioPhysicalObjectDTO]:
@@ -233,7 +237,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_context_physical_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         physical_object_function_id: int | None,
     ) -> list[PhysicalObjectDataDTO]:
@@ -302,7 +306,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_services_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         service_type_id: int | None,
         urban_function_id: int | None,
     ) -> list[ScenarioServiceDTO]:
@@ -317,7 +321,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_context_services_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         service_type_id: int | None,
         urban_function_id: int | None,
     ) -> list[ServiceDTO]:
@@ -364,7 +368,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_geometries_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_id: int | None,
         service_id: int | None,
     ) -> list[ScenarioGeometryDTO]:
@@ -379,7 +383,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_geometries_with_all_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         service_type_id: int | None,
         physical_object_function_id: int | None,
@@ -398,7 +402,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_context_geometries_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_id: int | None,
         service_id: int | None,
     ) -> list[ObjectGeometryDTO]:
@@ -413,7 +417,7 @@ class UserProjectServiceImpl(UserProjectService):
     async def get_context_geometries_with_all_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         service_type_id: int | None,
         physical_object_function_id: int | None,
@@ -471,7 +475,7 @@ class UserProjectServiceImpl(UserProjectService):
         indicator_group_id: int | None,
         territory_id: int | None,
         hexagon_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[ProjectIndicatorValueDTO]:
         return await get_projects_indicators_values_by_scenario_id_from_db(
             self._conn,
@@ -484,7 +488,7 @@ class UserProjectServiceImpl(UserProjectService):
         )
 
     async def get_project_indicator_value_by_id(
-        self, indicator_value_id: int, user_id: str
+        self, indicator_value_id: int, user_id: str | None
     ) -> ProjectIndicatorValueDTO:
         return await get_project_indicator_value_by_id_from_db(self._conn, indicator_value_id, user_id)
 
@@ -514,14 +518,14 @@ class UserProjectServiceImpl(UserProjectService):
         scenario_id: int,
         indicator_ids: str | None,
         indicators_group_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[HexagonWithIndicatorsDTO]:
         return await get_hexagons_with_indicators_by_scenario_id_from_db(
             self._conn, scenario_id, indicator_ids, indicators_group_id, user_id
         )
 
     async def get_functional_zones_sources_by_scenario_id(
-        self, scenario_id: int, user_id: str
+        self, scenario_id: int, user_id: str | None
     ) -> list[FunctionalZoneSourceDTO]:
         return await get_functional_zones_sources_by_scenario_id_from_db(self._conn, scenario_id, user_id)
 
@@ -531,14 +535,14 @@ class UserProjectServiceImpl(UserProjectService):
         year: int,
         source: str,
         functional_zone_type_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[ProjectProfileDTO]:
         return await get_functional_zones_by_scenario_id_from_db(
             self._conn, scenario_id, year, source, functional_zone_type_id, user_id
         )
 
     async def get_context_functional_zones_sources_by_scenario_id(
-        self, scenario_id: int, user_id: str
+        self, scenario_id: int, user_id: str | None
     ) -> list[FunctionalZoneSourceDTO]:
         return await get_context_functional_zones_sources_by_scenario_id_from_db(self._conn, scenario_id, user_id)
 
@@ -548,7 +552,7 @@ class UserProjectServiceImpl(UserProjectService):
         year: int,
         source: str,
         functional_zone_type_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[FunctionalZoneDataDTO]:
         return await get_context_functional_zones_by_scenario_id_from_db(
             self._conn, scenario_id, year, source, functional_zone_type_id, user_id

--- a/idu_api/urban_api/logic/projects.py
+++ b/idu_api/urban_api/logic/projects.py
@@ -50,11 +50,11 @@ class UserProjectService(Protocol):
     """Service to manipulate projects objects."""
 
     @abc.abstractmethod
-    async def get_project_by_id(self, project_id: int, user_id: str) -> ProjectDTO:
+    async def get_project_by_id(self, project_id: int, user_id: str | None) -> ProjectDTO:
         """Get project object by id."""
 
     @abc.abstractmethod
-    async def get_project_territory_by_id(self, project_id: int, user_id: str) -> ProjectTerritoryDTO:
+    async def get_project_territory_by_id(self, project_id: int, user_id: str | None) -> ProjectTerritoryDTO:
         """Get project territory object by id."""
 
     @abc.abstractmethod
@@ -114,25 +114,29 @@ class UserProjectService(Protocol):
         """Create project image preview and upload it (full and preview) to minio bucket."""
 
     @abc.abstractmethod
-    async def get_full_project_image(self, minio_client: AsyncMinioClient, project_id: int, user_id: str) -> io.BytesIO:
+    async def get_full_project_image(
+        self, minio_client: AsyncMinioClient, project_id: int, user_id: str | None
+    ) -> io.BytesIO:
         """Get full image for given project."""
 
     @abc.abstractmethod
     async def get_preview_project_image(
-        self, minio_client: AsyncMinioClient, project_id: int, user_id: str
+        self, minio_client: AsyncMinioClient, project_id: int, user_id: str | None
     ) -> io.BytesIO:
         """Get preview image for given project."""
 
     @abc.abstractmethod
-    async def get_full_project_image_url(self, minio_client: AsyncMinioClient, project_id: int, user_id: str) -> str:
+    async def get_full_project_image_url(
+        self, minio_client: AsyncMinioClient, project_id: int, user_id: str | None
+    ) -> str:
         """Get full image url for given project."""
 
     @abc.abstractmethod
-    async def get_scenarios_by_project_id(self, project_id: int, user_id: str) -> list[ScenarioDTO]:
+    async def get_scenarios_by_project_id(self, project_id: int, user_id: str | None) -> list[ScenarioDTO]:
         """Get list of scenario objects by project id."""
 
     @abc.abstractmethod
-    async def get_scenario_by_id(self, scenario_id: int, user_id: str) -> ScenarioDTO:
+    async def get_scenario_by_id(self, scenario_id: int, user_id: str | None) -> ScenarioDTO:
         """Get scenario object by id."""
 
     @abc.abstractmethod
@@ -159,7 +163,7 @@ class UserProjectService(Protocol):
     async def get_physical_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         physical_object_function_id: int | None,
     ) -> list[ScenarioPhysicalObjectDTO]:
@@ -169,7 +173,7 @@ class UserProjectService(Protocol):
     async def get_context_physical_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         physical_object_function_id: int | None,
     ) -> list[PhysicalObjectDataDTO]:
@@ -231,7 +235,7 @@ class UserProjectService(Protocol):
     async def get_services_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         service_type_id: int | None,
         urban_function_id: int | None,
     ) -> list[ScenarioServiceDTO]:
@@ -241,7 +245,7 @@ class UserProjectService(Protocol):
     async def get_context_services_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         service_type_id: int | None,
         urban_function_id: int | None,
     ) -> list[ServiceDTO]:
@@ -287,7 +291,7 @@ class UserProjectService(Protocol):
     async def get_geometries_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_id: int | None,
         service_id: int | None,
     ) -> list[ScenarioGeometryDTO]:
@@ -297,7 +301,7 @@ class UserProjectService(Protocol):
     async def get_geometries_with_all_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         service_type_id: int | None,
         physical_object_function_id: int | None,
@@ -309,7 +313,7 @@ class UserProjectService(Protocol):
     async def get_context_geometries_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_id: int | None,
         service_id: int | None,
     ) -> list[ObjectGeometryDTO]:
@@ -319,7 +323,7 @@ class UserProjectService(Protocol):
     async def get_context_geometries_with_all_objects_by_scenario_id(
         self,
         scenario_id: int,
-        user_id: str,
+        user_id: str | None,
         physical_object_type_id: int | None,
         service_type_id: int | None,
         physical_object_function_id: int | None,
@@ -367,14 +371,14 @@ class UserProjectService(Protocol):
         indicator_group_id: int | None,
         territory_id: int | None,
         hexagon_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[ProjectIndicatorValueDTO]:
         """Get project's indicators values for given scenario
         if relevant project is public or if you're the project owner."""
 
     @abc.abstractmethod
     async def get_project_indicator_value_by_id(
-        self, indicator_value_id: int, user_id: str
+        self, indicator_value_id: int, user_id: str | None
     ) -> ProjectIndicatorValueDTO:
         """Get project's specific indicator values for given scenario
         if relevant project is public or if you're the project owner."""
@@ -411,13 +415,13 @@ class UserProjectService(Protocol):
         scenario_id: int,
         indicator_ids: str | None,
         indicators_group_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[HexagonWithIndicatorsDTO]:
         """Get project's indicators values for given regional scenario with hexagons."""
 
     @abc.abstractmethod
     async def get_functional_zones_sources_by_scenario_id(
-        self, scenario_id: int, user_id: str
+        self, scenario_id: int, user_id: str | None
     ) -> list[FunctionalZoneSourceDTO]:
         """Get list of pairs year + source for functional zones for given scenario."""
 
@@ -428,13 +432,13 @@ class UserProjectService(Protocol):
         year: int,
         source: str,
         functional_zone_type_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[ProjectProfileDTO]:
         """Get list of functional zone objects by scenario identifier."""
 
     @abc.abstractmethod
     async def get_context_functional_zones_sources_by_scenario_id(
-        self, scenario_id: int, user_id: str
+        self, scenario_id: int, user_id: str | None
     ) -> list[FunctionalZoneSourceDTO]:
         """Get list of pairs year + source for functional zones for 'context' of the project territory."""
 
@@ -445,7 +449,7 @@ class UserProjectService(Protocol):
         year: int,
         source: str,
         functional_zone_type_id: int | None,
-        user_id: str,
+        user_id: str | None,
     ) -> list[FunctionalZoneDataDTO]:
         """Get list of functional zone objects for 'context' of the project territory."""
 

--- a/idu_api/urban_api/logic/projects.py
+++ b/idu_api/urban_api/logic/projects.py
@@ -137,7 +137,11 @@ class UserProjectService(Protocol):
 
     @abc.abstractmethod
     async def add_scenario(self, scenario: ScenariosPost, user_id: str) -> ScenarioDTO:
-        """Create scenario object."""
+        """Create scenario object from base scenario."""
+
+    @abc.abstractmethod
+    async def copy_scenario(self, scenario: ScenariosPost, scenario_id: int, user_id: str) -> ScenarioDTO:
+        """Create a new scenario from another scenario (copy) by its identifier."""
 
     @abc.abstractmethod
     async def put_scenario(self, scenario: ScenariosPut, scenario_id: int, user_id) -> ScenarioDTO:
@@ -383,7 +387,7 @@ class UserProjectService(Protocol):
 
     @abc.abstractmethod
     async def put_projects_indicator_value(
-        self, projects_indicator: ProjectIndicatorValuePut, indicator_value_id: int, user_id: str
+        self, projects_indicator: ProjectIndicatorValuePut, user_id: str
     ) -> ProjectIndicatorValueDTO:
         """Put project's indicator value."""
 

--- a/idu_api/urban_api/schemas/indicators.py
+++ b/idu_api/urban_api/schemas/indicators.py
@@ -40,6 +40,7 @@ class ShortIndicatorInfo(BaseModel):
     """Basic indicator model to encapsulate in other models."""
 
     indicator_id: int = Field(..., examples=[1])
+    parent_id: int = Field(..., description="parent indicator identifier", examples=[1])
     name_full: str = Field(
         ...,
         description="indicator unit full name",
@@ -234,6 +235,7 @@ class IndicatorValue(BaseModel):
         return cls(
             indicator=ShortIndicatorInfo(
                 indicator_id=dto.indicator_id,
+                parent_id=dto.parent_id,
                 name_full=dto.name_full,
                 level=dto.level,
                 list_label=dto.list_label,
@@ -302,23 +304,17 @@ class IndicatorValuePost(BaseModel):
 class ProjectIndicatorValue(BaseModel):
     """Project indicator value with all its attributes."""
 
+    indicator_value_id: int = Field(..., description="indicator value identifier", examples=[1])
     indicator: ShortIndicatorInfo
     scenario: ShortScenario
     territory: ShortTerritory | None
     hexagon_id: int | None
     value: float = Field(..., description="indicator value for scenario at time", examples=[23.5])
     comment: str | None = Field(None, description="comment for indicator value", examples=["--"])
-    information_source: str | None = Field(
-        ...,
-        description="information source",
-        examples=[
-            "https://data.gov.spb.ru/irsi/7832000076-Obuekty-nedvizhimogo-imushestva-i-zemelnye-uchastki/"
-            "structure_version/229/"
-        ],
-    )
+    information_source: str | None = Field(..., description="information source", examples=["modeled"])
     properties: dict[str, Any] = Field(
         default_factory=dict,
-        description="scenario additional properties",
+        description="scenario indicator value additional properties",
         examples=[{"attribute_name": "attribute_value"}],
     )
     created_at: datetime = Field(
@@ -334,8 +330,10 @@ class ProjectIndicatorValue(BaseModel):
         Construct from DTO.
         """
         return cls(
+            indicator_value_id=dto.indicator_value_id,
             indicator=ShortIndicatorInfo(
                 indicator_id=dto.indicator_id,
+                parent_id=dto.parent_id,
                 name_full=dto.name_full,
                 level=dto.level,
                 list_label=dto.list_label,
@@ -370,6 +368,26 @@ class ProjectIndicatorValuePost(BaseModel):
     """Project indicator value schema for POST requests."""
 
     indicator_id: int = Field(..., description="indicator identifier", examples=[1])
+    territory_id: int | None = Field(
+        None, description="real territory identifier for which indicator value was saved", examples=[1]
+    )
+    hexagon_id: int | None = Field(
+        None, description="hexagon identifier for which indicator value was saved", examples=[1]
+    )
+    value: float = Field(..., description="indicator value for territory at time", examples=[23.5])
+    comment: str | None = Field(..., description="comment for indicator value", examples=["--"])
+    information_source: str | None = Field(..., description="information source", examples=["modeled"])
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="scenario indicator value additional properties",
+        examples=[{"attribute_name": "attribute_value"}],
+    )
+
+
+class ProjectIndicatorValuePut(BaseModel):
+    """Project indicator value schema for PUT requests."""
+
+    indicator_id: int = Field(..., description="indicator identifier", examples=[1])
     scenario_id: int = Field(..., description="scenario identifier for which indicator value was saved", examples=[1])
     territory_id: int | None = Field(
         ..., description="real territory identifier for which indicator value was saved", examples=[1]
@@ -379,37 +397,10 @@ class ProjectIndicatorValuePost(BaseModel):
     )
     value: float = Field(..., description="indicator value for territory at time", examples=[23.5])
     comment: str | None = Field(..., description="comment for indicator value", examples=["--"])
-    information_source: str | None = Field(
-        ...,
-        description="information source",
-        examples=[
-            "https://data.gov.spb.ru/irsi/7832000076-Obuekty-nedvizhimogo-imushestva-i-zemelnye-uchastki/"
-            "structure_version/229/"
-        ],
-    )
-    properties: dict[str, Any] = Field(
-        default_factory=dict,
-        description="scenario additional properties",
-        examples=[{"attribute_name": "attribute_value"}],
-    )
-
-
-class ProjectIndicatorValuePut(BaseModel):
-    """Project indicator value schema for PUT requests."""
-
-    value: float = Field(..., description="indicator value for territory at time", examples=[23.5])
-    comment: str | None = Field(..., description="comment for indicator value", examples=["--"])
-    information_source: str | None = Field(
-        ...,
-        description="information source",
-        examples=[
-            "https://data.gov.spb.ru/irsi/7832000076-Obuekty-nedvizhimogo-imushestva-i-zemelnye-uchastki/"
-            "structure_version/229/"
-        ],
-    )
+    information_source: str | None = Field(..., description="information source", examples=["modeled"])
     properties: dict[str, Any] = Field(
         ...,
-        description="scenario additional properties",
+        description="scenario indicator value additional properties",
         examples=[{"attribute_name": "attribute_value"}],
     )
 
@@ -429,7 +420,7 @@ class ProjectIndicatorValuePatch(BaseModel):
     )
     properties: dict[str, Any] | None = Field(
         None,
-        description="scenario additional properties",
+        description="scenario indicator value additional properties",
         examples=[{"attribute_name": "attribute_value"}],
     )
 

--- a/idu_api/urban_api/version.py
+++ b/idu_api/urban_api/version.py
@@ -1,4 +1,4 @@
 """Version constants are defined here and should be updated on release."""
 
-VERSION = "0.29.1"
+VERSION = "0.30.0"
 LAST_UPDATE = "2024-12-03"

--- a/idu_api/urban_api/version.py
+++ b/idu_api/urban_api/version.py
@@ -1,4 +1,4 @@
 """Version constants are defined here and should be updated on release."""
 
-VERSION = "0.30.0"
+VERSION = "0.30.1"
 LAST_UPDATE = "2024-12-03"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idu-api"
-version = "1.22.0"
+version = "1.22.1"
 description = "This is a Digital Territories Platform API in two versions to access and manipulate basic territories data."
 authors = ["Babayev Ruslan <rus.babaef@yandex.ru>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "idu-api"
-version = "1.21.1"
+version = "1.22.0"
 description = "This is a Digital Territories Platform API in two versions to access and manipulate basic territories data."
 authors = ["Babayev Ruslan <rus.babaef@yandex.ru>"]
 readme = "README.md"


### PR DESCRIPTION
Changes:
- new migrations (fix `list_label` triggers and add unique constraint on `user_projects.indicators_data`)
- add method to copy scenario (create from another)
- fix indicator value put method (it create new if not exists else update now)
- fix (project) indicator value schema (add indicator `parent_id`, `indicator_value_id`)
- fix access for projects methods (remove `HTTPBearer` dependency for get methods, with descriptions)